### PR TITLE
Fix/loading indicator

### DIFF
--- a/ThunderRequest.xcodeproj/project.pbxproj
+++ b/ThunderRequest.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		B12F7CA91BFDD6B9002B7D60 /* NSURLSession+Synchronous.h in Headers */ = {isa = PBXBuildFile; fileRef = B19894871BEA3B7C00E96DA3 /* NSURLSession+Synchronous.h */; };
 		B12F7CAA1BFDD6BD002B7D60 /* NSURLSession+Synchronous.m in Sources */ = {isa = PBXBuildFile; fileRef = B19894881BEA3B7C00E96DA3 /* NSURLSession+Synchronous.m */; };
 		B12F7CAB1BFDD836002B7D60 /* NSThread+Blocks.m in Sources */ = {isa = PBXBuildFile; fileRef = B1AB78341BDA92CC00F50127 /* NSThread+Blocks.m */; };
+		B15560F41CBE3FEB00834825 /* ApplicationLoadingIndicatorManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15560F31CBE3FEB00834825 /* ApplicationLoadingIndicatorManager.swift */; };
 		B16743E81BA6C4E000352C68 /* TSCOAuth2Manager.h in Headers */ = {isa = PBXBuildFile; fileRef = B16743E61BA6C4E000352C68 /* TSCOAuth2Manager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B16ED2141C59337800ABCC35 /* TSCRequest+TaskIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = B16ED2121C59337800ABCC35 /* TSCRequest+TaskIdentifier.h */; };
 		B16ED2151C59337800ABCC35 /* TSCRequest+TaskIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = B16ED2121C59337800ABCC35 /* TSCRequest+TaskIdentifier.h */; };
@@ -129,6 +130,7 @@
 		B1177EE21BBAF18E00372D4D /* ThunderRequestMacTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ThunderRequestMacTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B1177EE81BBAF18E00372D4D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B1177EE91BBAF18E00372D4D /* ThunderRequestMacTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ThunderRequestMacTests.m; sourceTree = "<group>"; };
+		B15560F31CBE3FEB00834825 /* ApplicationLoadingIndicatorManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplicationLoadingIndicatorManager.swift; sourceTree = "<group>"; };
 		B16743E61BA6C4E000352C68 /* TSCOAuth2Manager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TSCOAuth2Manager.h; sourceTree = "<group>"; };
 		B16ED2121C59337800ABCC35 /* TSCRequest+TaskIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "TSCRequest+TaskIdentifier.h"; sourceTree = "<group>"; };
 		B16ED2131C59337800ABCC35 /* TSCRequest+TaskIdentifier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "TSCRequest+TaskIdentifier.m"; sourceTree = "<group>"; };
@@ -270,6 +272,7 @@
 			isa = PBXGroup;
 			children = (
 				C2E5089B19C835D900350F00 /* ThunderRequest.h */,
+				B15560F31CBE3FEB00834825 /* ApplicationLoadingIndicatorManager.swift */,
 				B16ED2121C59337800ABCC35 /* TSCRequest+TaskIdentifier.h */,
 				B16ED2131C59337800ABCC35 /* TSCRequest+TaskIdentifier.m */,
 				B1BA54ED1CBB9F4700C74C06 /* NSMutableURLRequest+TaskIdentifier.h */,
@@ -499,7 +502,7 @@
 		C2E5087919C835A300350F00 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0700;
+				LastSwiftUpdateCheck = 0730;
 				LastUpgradeCheck = 0730;
 				ORGANIZATIONNAME = threesidedcube;
 				TargetAttributes = {
@@ -640,6 +643,7 @@
 				C2E508AC19C835D900350F00 /* TSCRequestResponse.m in Sources */,
 				C2E508A819C835D900350F00 /* TSCRequestController.m in Sources */,
 				B16ED2171C59337800ABCC35 /* TSCRequest+TaskIdentifier.m in Sources */,
+				B15560F41CBE3FEB00834825 /* ApplicationLoadingIndicatorManager.swift in Sources */,
 				B1AB78361BDA92CC00F50127 /* NSThread+Blocks.m in Sources */,
 				49B77E0F1B36A7BF001475CE /* TSCErrorRecoveryAttempter.m in Sources */,
 				C2E508A619C835D900350F00 /* TSCRequest.m in Sources */,
@@ -894,6 +898,7 @@
 		C2E5089619C835A300350F00 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -907,12 +912,14 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.threesidedcube.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
 		};
 		C2E5089719C835A300350F00 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;

--- a/ThunderRequest/ApplicationLoadingIndicatorManager.swift
+++ b/ThunderRequest/ApplicationLoadingIndicatorManager.swift
@@ -1,0 +1,35 @@
+//
+//  ApplicationLoadingIndicatorManager.swift
+//  ThunderRequest
+//
+//  Created by Simon Mitchell on 13/04/2016.
+//  Copyright © 2016 threesidedcube. All rights reserved.
+//
+
+import UIKit
+
+public class ApplicationLoadingIndicatorManager: NSObject {
+    
+    public static let sharedManager = ApplicationLoadingIndicatorManager()
+    private var activityCount = 0
+        
+    public func showActivityIndicator() {
+        
+        objc_sync_enter(self)
+        if activityCount == 0 {
+            UIApplication.sharedApplication().networkActivityIndicatorVisible = true
+        }
+        activityCount += 1
+        objc_sync_exit(self)
+    }
+    
+    public func hideActivityIndicator() {
+        
+        objc_sync_enter(self)
+        activityCount -= 1
+        if activityCount <= 0 {
+            UIApplication.sharedApplication().networkActivityIndicatorVisible = false
+        }
+        objc_sync_exit(self)
+    }
+}

--- a/ThunderRequest/TSCRequestController.m
+++ b/ThunderRequest/TSCRequestController.m
@@ -336,7 +336,6 @@ typedef void (^TSCOAuth2CheckCompletion) (BOOL authenticated, NSError *authError
 
 - (void)TSC_fireRequestCompletionWithData:(NSData *)data response:(NSURLResponse *)response error:(NSError *)error request:(TSCRequest *)request completion:(TSCRequestCompletionHandler)completion onThread:(NSThread *)scheduleThread
 {
-    NSLog(@"Request finished");
     TSCRequestResponse *requestResponse = [[TSCRequestResponse alloc] initWithResponse:response data:data];
     
     if (request.taskIdentifier && self.redirectResponses[@(request.taskIdentifier)]) {
@@ -481,11 +480,11 @@ typedef void (^TSCOAuth2CheckCompletion) (BOOL authenticated, NSError *authError
 {
     __weak typeof(self) welf = self;
     
-    //Loading
+    //Loading (Only if we're the first request)
     #if TARGET_OS_IOS
-        if (![[[NSBundle mainBundle] objectForInfoDictionaryKey:@"TSCThunderRequestShouldHideActivityIndicator"] boolValue]){
-            [UIApplication sharedApplication].networkActivityIndicatorVisible = YES;
-        }
+    if (self.defaultRequestQueue.operationCount == 0 && self.backgroundRequestQueue.operationCount == 0 && self.ephemeralRequestQueue.operationCount == 0) {
+        [UIApplication sharedApplication].networkActivityIndicatorVisible = true;
+    }
     #endif
     
     [request prepareForDispatch];
@@ -525,11 +524,11 @@ typedef void (^TSCOAuth2CheckCompletion) (BOOL authenticated, NSError *authError
 {
     __weak typeof(self) welf = self;
     
-    //Loading
+    //Loading (Only if we're the first request)
     #if TARGET_OS_IOS
-        if (![[[NSBundle mainBundle] objectForInfoDictionaryKey:@"TSCThunderRequestShouldHideActivityIndicator"] boolValue]){
-            [UIApplication sharedApplication].networkActivityIndicatorVisible = YES;
-        }
+    if (self.defaultRequestQueue.operationCount == 0 && self.backgroundRequestQueue.operationCount == 0 && self.ephemeralRequestQueue.operationCount == 0) {
+        [UIApplication sharedApplication].networkActivityIndicatorVisible = true;
+    }
     #endif
     
     [self checkOAuthStatusWithRequest:request completion:^(BOOL authenticated, NSError *error, BOOL needsQueueing) {
@@ -583,13 +582,13 @@ typedef void (^TSCOAuth2CheckCompletion) (BOOL authenticated, NSError *authError
     // Check OAuth status before making the request
     __weak typeof(self) welf = self;
     
-    //Loading
+    //Loading (Only if we're the first request)
     #if TARGET_OS_IOS
-        if (![[[NSBundle mainBundle] objectForInfoDictionaryKey:@"TSCThunderRequestShouldHideActivityIndicator"] boolValue]){
-            [UIApplication sharedApplication].networkActivityIndicatorVisible = YES;
-        }
+    if (self.defaultRequestQueue.operationCount == 0 && self.backgroundRequestQueue.operationCount == 0 && self.ephemeralRequestQueue.operationCount == 0) {
+        [UIApplication sharedApplication].networkActivityIndicatorVisible = true;
+    }
     #endif
-    
+
     NSString *userAgent = [[NSUserDefaults standardUserDefaults] stringForKey:@"TSCUserAgent"];
     if (userAgent) {
         [request.requestHeaders setValue:userAgent forKey:@"User-Agent"];
@@ -823,7 +822,7 @@ typedef void (^TSCOAuth2CheckCompletion) (BOOL authenticated, NSError *authError
 {
     if (self.defaultRequestQueue.operationCount == 0 && self.backgroundRequestQueue.operationCount == 0 && self.ephemeralRequestQueue.operationCount == 0) {
     #if TARGET_OS_IOS
-        [UIApplication sharedApplication].networkActivityIndicatorVisible = NO;
+        [UIApplication sharedApplication].networkActivityIndicatorVisible = false;
     #endif    
     }
 }

--- a/ThunderRequest/TSCRequestController.m
+++ b/ThunderRequest/TSCRequestController.m
@@ -10,7 +10,7 @@
 #import "TSCRequest+TaskIdentifier.h"
 #import <objc/runtime.h>
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IOS
 #import <ThunderRequest/ThunderRequest-Swift.h>
 #endif
 


### PR DESCRIPTION
Makes the application loading indicator state more manageable across instances of TSCRequestController by creating a shared instance of a controller which manages a count of how many times it has been turned on/off
