### PR TITLE
Moves showing network activity indicator to main thread

### DIFF
--- a/ThunderRequest/ApplicationLoadingIndicatorManager.swift
+++ b/ThunderRequest/ApplicationLoadingIndicatorManager.swift
@@ -17,7 +17,10 @@ open class ApplicationLoadingIndicatorManager: NSObject {
         
         objc_sync_enter(self)
         if activityCount == 0 {
-            UIApplication.shared.isNetworkActivityIndicatorVisible = true
+            
+            OperationQueue.main.addOperation({ 
+                UIApplication.shared.isNetworkActivityIndicatorVisible = true
+            })
         }
         activityCount += 1
         objc_sync_exit(self)
@@ -28,7 +31,10 @@ open class ApplicationLoadingIndicatorManager: NSObject {
         objc_sync_enter(self)
         activityCount -= 1
         if activityCount <= 0 {
-            UIApplication.shared.isNetworkActivityIndicatorVisible = false
+            
+            OperationQueue.main.addOperation({
+                UIApplication.shared.isNetworkActivityIndicatorVisible = false
+            })
         }
         objc_sync_exit(self)
     }

--- a/ThunderRequest/TSCRequestController.m
+++ b/ThunderRequest/TSCRequestController.m
@@ -847,10 +847,7 @@ typedef void (^TSCOAuth2CheckCompletion) (BOOL authenticated, NSError *authError
 {
 #if TARGET_OS_IOS
     if (![[[NSBundle mainBundle] objectForInfoDictionaryKey:@"TSCThunderRequestShouldHideActivityIndicator"] boolValue]) {
-        [[NSOperationQueue mainQueue] addOperationWithBlock:^{
-            [ApplicationLoadingIndicatorManager.sharedManager showActivityIndicator];
-        }];
-        
+        [ApplicationLoadingIndicatorManager.sharedManager showActivityIndicator];
     }
 #endif
 }
@@ -859,9 +856,7 @@ typedef void (^TSCOAuth2CheckCompletion) (BOOL authenticated, NSError *authError
 {
 #if TARGET_OS_IOS
     if (![[[NSBundle mainBundle] objectForInfoDictionaryKey:@"TSCThunderRequestShouldHideActivityIndicator"] boolValue]) {
-        [[NSOperationQueue mainQueue] addOperationWithBlock:^{
-            [ApplicationLoadingIndicatorManager.sharedManager hideActivityIndicator];
-        }];
+        [ApplicationLoadingIndicatorManager.sharedManager hideActivityIndicator];
     }
 #endif
 }

--- a/ThunderRequest/TSCRequestController.m
+++ b/ThunderRequest/TSCRequestController.m
@@ -847,7 +847,10 @@ typedef void (^TSCOAuth2CheckCompletion) (BOOL authenticated, NSError *authError
 {
 #if TARGET_OS_IOS
     if (![[[NSBundle mainBundle] objectForInfoDictionaryKey:@"TSCThunderRequestShouldHideActivityIndicator"] boolValue]) {
-        [ApplicationLoadingIndicatorManager.sharedManager showActivityIndicator];
+        [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+            [ApplicationLoadingIndicatorManager.sharedManager showActivityIndicator];
+        }];
+        
     }
 #endif
 }
@@ -856,7 +859,9 @@ typedef void (^TSCOAuth2CheckCompletion) (BOOL authenticated, NSError *authError
 {
 #if TARGET_OS_IOS
     if (![[[NSBundle mainBundle] objectForInfoDictionaryKey:@"TSCThunderRequestShouldHideActivityIndicator"] boolValue]) {
-        [ApplicationLoadingIndicatorManager.sharedManager hideActivityIndicator];
+        [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+            [ApplicationLoadingIndicatorManager.sharedManager hideActivityIndicator];
+        }];
     }
 #endif
 }


### PR DESCRIPTION
New Xcode shows UI methods being called on background threads, it picked up this one straight away and I imagine will trigger in most of our apps.  