### PR TITLE
Fix/content type

### DIFF
--- a/ThunderRequest/TSCRequest.m
+++ b/ThunderRequest/TSCRequest.m
@@ -32,7 +32,7 @@
 	
 	// We don't set the content-type header for GET requests as they shouldn't be sending data
 	// and some APIs will error if you provide a Content-Type with no data!
-	if (self.HTTPMethod == TSCRequestHTTPMethodGET && self.HTTPBody) {
+	if (self.HTTPMethod != TSCRequestHTTPMethodGET && self.HTTPBody) {
 		[self setValue:[self TSC_contentTypeStringForContentType:self.contentType] forHTTPHeaderField:@"Content-Type"];
 		[self.requestHeaders setValue:[self TSC_contentTypeStringForContentType:self.contentType] forKey:@"Content-Type"];
 	}

--- a/ThunderRequest/TSCRequest.m
+++ b/ThunderRequest/TSCRequest.m
@@ -38,7 +38,7 @@
 	}
 	
 	if (self.HTTPMethod == TSCRequestHTTPMethodGET && self.HTTPBody) {
-		NSLog(@"<ThunderRequest> Invalid request to: %@. Should not be sending a GET request with a non-nil body", self.URL.absoluteString)
+		NSLog(@"<ThunderRequest> Invalid request to: %@. Should not be sending a GET request with a non-nil body", self.URL.absoluteString);
 	}
 	
     for (NSString *key in [self.requestHeaders allKeys]) {

--- a/ThunderRequest/TSCRequest.m
+++ b/ThunderRequest/TSCRequest.m
@@ -29,8 +29,18 @@
     
     self.HTTPMethod = [self stringForHTTPMethod:self.requestHTTPMethod];
     self.HTTPBody = [self HTTPBodyWithDictionary:self.bodyParameters];
-    [self setValue:[self TSC_contentTypeStringForContentType:self.contentType] forHTTPHeaderField:@"Content-Type"];
-    [self.requestHeaders setValue:[self TSC_contentTypeStringForContentType:self.contentType] forKey:@"Content-Type"];
+	
+	// We don't set the content-type header for GET requests as they shouldn't be sending data
+	// and some APIs will error if you provide a Content-Type with no data!
+	if (self.HTTPMethod == TSCRequestHTTPMethodGET && self.HTTPBody) {
+		[self setValue:[self TSC_contentTypeStringForContentType:self.contentType] forHTTPHeaderField:@"Content-Type"];
+		[self.requestHeaders setValue:[self TSC_contentTypeStringForContentType:self.contentType] forKey:@"Content-Type"];
+	}
+	
+	if (self.HTTPMethod == TSCRequestHTTPMethodGET && self.HTTPBody) {
+		NSLog(@"<ThunderRequest> Invalid request to: %@. Should not be sending a GET request with a non-nil body", self.URL.absoluteString)
+	}
+	
     for (NSString *key in [self.requestHeaders allKeys]) {
         [self setValue:self.requestHeaders[key] forHTTPHeaderField:key];
     }

--- a/ThunderRequest/TSCRequestController.m
+++ b/ThunderRequest/TSCRequestController.m
@@ -88,355 +88,349 @@ typedef void (^TSCOAuth2CheckCompletion) (BOOL authenticated, NSError *authError
 
 - (instancetype)init
 {
-    self = [super init];
-    if (self) {
-        
-        self.verboseLogging = [[[NSBundle mainBundle] objectForInfoDictionaryKey:@"TSCThunderRequestVerboseLogging"] boolValue];
-        self.truncatesVerboseResponse = [[[NSBundle mainBundle] objectForInfoDictionaryKey:@"TSCThunderRequestTruncatesVerboseResponse"] boolValue];
-        
-        self.defaultRequestQueue = [NSOperationQueue new];
-        self.backgroundRequestQueue = [NSOperationQueue new];
-        self.ephemeralRequestQueue = [NSOperationQueue new];
-        
-        NSURLSessionConfiguration *defaultConfigObject = [NSURLSessionConfiguration defaultSessionConfiguration];
-        NSURLSessionConfiguration *backgroundConfigObject = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:[[NSUUID UUID] UUIDString]];
-        NSURLSessionConfiguration *ephemeralConfigObject = [NSURLSessionConfiguration ephemeralSessionConfiguration];
-        
-        self.defaultSession = [NSURLSession sessionWithConfiguration:defaultConfigObject delegate:self delegateQueue:self.defaultRequestQueue];
-        self.backgroundSession = [NSURLSession sessionWithConfiguration:backgroundConfigObject delegate:self delegateQueue:self.backgroundRequestQueue];
-        self.ephemeralSession = [NSURLSession sessionWithConfiguration:ephemeralConfigObject delegate:nil delegateQueue:self.ephemeralRequestQueue];
-        
-        self.completionHandlerDictionary = [NSMutableDictionary dictionary];
-        self.sharedRequestHeaders = [NSMutableDictionary dictionary];
-
-        self.authQueuedRequests = [NSMutableArray new];
-        self.redirectResponses = [NSMutableDictionary new];
-
-    }
-    return self;
+	self = [super init];
+	if (self) {
+		
+		self.verboseLogging = [[[NSBundle mainBundle] objectForInfoDictionaryKey:@"TSCThunderRequestVerboseLogging"] boolValue];
+		self.truncatesVerboseResponse = [[[NSBundle mainBundle] objectForInfoDictionaryKey:@"TSCThunderRequestTruncatesVerboseResponse"] boolValue];
+		
+		self.defaultRequestQueue = [NSOperationQueue new];
+		self.backgroundRequestQueue = [NSOperationQueue new];
+		self.ephemeralRequestQueue = [NSOperationQueue new];
+		
+		NSURLSessionConfiguration *defaultConfigObject = [NSURLSessionConfiguration defaultSessionConfiguration];
+		NSURLSessionConfiguration *backgroundConfigObject = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:[[NSUUID UUID] UUIDString]];
+		NSURLSessionConfiguration *ephemeralConfigObject = [NSURLSessionConfiguration ephemeralSessionConfiguration];
+		
+		self.defaultSession = [NSURLSession sessionWithConfiguration:defaultConfigObject delegate:self delegateQueue:self.defaultRequestQueue];
+		self.backgroundSession = [NSURLSession sessionWithConfiguration:backgroundConfigObject delegate:self delegateQueue:self.backgroundRequestQueue];
+		self.ephemeralSession = [NSURLSession sessionWithConfiguration:ephemeralConfigObject delegate:nil delegateQueue:self.ephemeralRequestQueue];
+		
+		self.completionHandlerDictionary = [NSMutableDictionary dictionary];
+		self.sharedRequestHeaders = [NSMutableDictionary dictionary];
+		
+		self.authQueuedRequests = [NSMutableArray new];
+		self.redirectResponses = [NSMutableDictionary new];
+		
+	}
+	return self;
 }
 
 + (void)setUserAgent:(NSString *)userAgent
 {
-    if (userAgent) {
-        [[NSUserDefaults standardUserDefaults] setValue:userAgent forKey:@"TSCUserAgent"];
-    } else {
-        [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"TSCUserAgent"];
-    }
+	if (userAgent) {
+		[[NSUserDefaults standardUserDefaults] setValue:userAgent forKey:@"TSCUserAgent"];
+	} else {
+		[[NSUserDefaults standardUserDefaults] removeObjectForKey:@"TSCUserAgent"];
+	}
 }
 
 - (nonnull instancetype)initWithBaseURL:(nullable NSURL *)baseURL
 {
-    self = [self init];
-    if (self) {
-        
-        if ([baseURL.absoluteString hasSuffix:@"/"]) {
-            self.sharedBaseURL = baseURL;
-        } else {
-            self.sharedBaseURL = [NSURL URLWithString:[baseURL.absoluteString stringByAppendingString:@"/"]];
-        }
-        
-        self.sharedRequestCredential = [TSCRequestCredential retrieveCredentialWithIdentifier:[NSString stringWithFormat:@"thundertable.com.threesidedcube-%@", self.sharedBaseURL]];
-    }
-    return self;
+	self = [self init];
+	if (self) {
+		
+		if ([baseURL.absoluteString hasSuffix:@"/"]) {
+			self.sharedBaseURL = baseURL;
+		} else {
+			self.sharedBaseURL = [NSURL URLWithString:[baseURL.absoluteString stringByAppendingString:@"/"]];
+		}
+		
+		self.sharedRequestCredential = [TSCRequestCredential retrieveCredentialWithIdentifier:[NSString stringWithFormat:@"thundertable.com.threesidedcube-%@", self.sharedBaseURL]];
+	}
+	return self;
 }
 
 - (nonnull instancetype)initWithBaseAddress:(nullable NSString *)baseAddress
 {
-    return [self initWithBaseURL:[NSURL URLWithString:baseAddress]];
+	return [self initWithBaseURL:[NSURL URLWithString:baseAddress]];
 }
 
 #pragma mark - GET Requests
 
 - (nonnull TSCRequest *)get:(nonnull NSString *)path completion:(nonnull TSCRequestCompletionHandler)completion
 {
-    return [self get:path withURLParamDictionary:nil completion:completion];
+	return [self get:path withURLParamDictionary:nil completion:completion];
 }
 
 - (nonnull TSCRequest *)get:(nonnull NSString *)path withURLParamDictionary:(nullable NSDictionary *)URLParamDictionary completion:(nonnull TSCRequestCompletionHandler)completion
 {
-    TSCRequest *request = [TSCRequest new];
-    request.baseURL = self.sharedBaseURL;
-    request.requestHTTPMethod = TSCRequestHTTPMethodGET;
-    request.path = path;
-    request.URLParameterDictionary = URLParamDictionary;
+	TSCRequest *request = [TSCRequest new];
+	request.baseURL = self.sharedBaseURL;
+	request.requestHTTPMethod = TSCRequestHTTPMethodGET;
+	request.path = path;
+	request.URLParameterDictionary = URLParamDictionary;
 	
 	NSMutableDictionary *requestHeaders = [self.sharedRequestHeaders mutableCopy];
 	// In some API's an error will be returned if you set a Content-Type header
 	// but don't pass a body (In the case of a GET request you never pass a body)
 	// so for GET requests we nill this out
 	[requestHeaders removeObjectForKey:@"Content-Type"];
-    request.requestHeaders = requestHeaders;
-
-    [self scheduleRequest:request completion:completion];
-    return request;
+	request.requestHeaders = requestHeaders;
+	
+	[self scheduleRequest:request completion:completion];
+	return request;
 }
 
 #pragma mark - POST Requests
 
 - (nonnull TSCRequest *)post:(nonnull NSString *)path bodyParams:(id)bodyParams completion:(nonnull TSCRequestCompletionHandler)completion
 {
-    return [self post:path withURLParamDictionary:nil bodyParams:bodyParams completion:completion];
+	return [self post:path withURLParamDictionary:nil bodyParams:bodyParams completion:completion];
 }
 
 - (nonnull TSCRequest *)post:(nonnull NSString *)path withURLParamDictionary:(nullable NSDictionary *)URLParamDictionary bodyParams:(id)bodyParams completion:(nonnull TSCRequestCompletionHandler)completion
 {
-    return [self post:path withURLParamDictionary:URLParamDictionary bodyParams:bodyParams contentType:TSCRequestContentTypeJSON completion:completion];
+	return [self post:path withURLParamDictionary:URLParamDictionary bodyParams:bodyParams contentType:TSCRequestContentTypeJSON completion:completion];
 }
 
 - (nonnull TSCRequest *)post:(nonnull NSString *)path withURLParamDictionary:(nullable NSDictionary *)URLParamDictionary bodyParams:(id)bodyParams contentType:(TSCRequestContentType)contentType completion:(nonnull TSCRequestCompletionHandler)completion
 {
-    TSCRequest *request = [TSCRequest new];
-    request.baseURL = self.sharedBaseURL;
-    request.path = path;
-    request.requestHTTPMethod = TSCRequestHTTPMethodPOST;
-    request.bodyParameters = bodyParams;
-    request.URLParameterDictionary = URLParamDictionary;
-    request.contentType = contentType;
-    request.requestHeaders = self.sharedRequestHeaders;
-
-    [self scheduleRequest:request completion:completion];
-    return request;
+	TSCRequest *request = [TSCRequest new];
+	request.baseURL = self.sharedBaseURL;
+	request.path = path;
+	request.requestHTTPMethod = TSCRequestHTTPMethodPOST;
+	request.bodyParameters = bodyParams;
+	request.URLParameterDictionary = URLParamDictionary;
+	request.contentType = contentType;
+	request.requestHeaders = self.sharedRequestHeaders;
+	
+	[self scheduleRequest:request completion:completion];
+	return request;
 }
 
 #pragma mark - PUT Requests
 - (nonnull TSCRequest *)put:(nonnull NSString *)path bodyParams:(id)bodyParams completion:(nonnull TSCRequestCompletionHandler)completion
 {
-    return [self put:path withURLParamDictionary:nil bodyParams:bodyParams completion:completion];
+	return [self put:path withURLParamDictionary:nil bodyParams:bodyParams completion:completion];
 }
 
 - (nonnull TSCRequest *)put:(nonnull NSString *)path withURLParamDictionary:(nullable NSDictionary *)URLParamDictionary bodyParams:(id)bodyParams completion:(nonnull TSCRequestCompletionHandler)completion
 {
-    return [self put:path withURLParamDictionary:URLParamDictionary bodyParams:bodyParams contentType:TSCRequestContentTypeJSON completion:completion];
+	return [self put:path withURLParamDictionary:URLParamDictionary bodyParams:bodyParams contentType:TSCRequestContentTypeJSON completion:completion];
 }
 
 - (nonnull TSCRequest *)put:(nonnull NSString *)path withURLParamDictionary:(nullable NSDictionary *)URLParamDictionary bodyParams:(id)bodyParams contentType:(TSCRequestContentType)contentType completion:(nonnull TSCRequestCompletionHandler)completion
 {
-    TSCRequest *request = [TSCRequest new];
-    request.baseURL = self.sharedBaseURL;
-    request.path = path;
-    request.requestHTTPMethod = TSCRequestHTTPMethodPUT;
-    request.bodyParameters = bodyParams;
-    request.URLParameterDictionary = URLParamDictionary;
-    request.contentType = contentType;
-    request.requestHeaders = self.sharedRequestHeaders;
-
-    [self scheduleRequest:request completion:completion];
-    return request;
+	TSCRequest *request = [TSCRequest new];
+	request.baseURL = self.sharedBaseURL;
+	request.path = path;
+	request.requestHTTPMethod = TSCRequestHTTPMethodPUT;
+	request.bodyParameters = bodyParams;
+	request.URLParameterDictionary = URLParamDictionary;
+	request.contentType = contentType;
+	request.requestHeaders = self.sharedRequestHeaders;
+	
+	[self scheduleRequest:request completion:completion];
+	return request;
 }
 
 #pragma mark - PATCH requests
 - (nonnull TSCRequest *)patch:(nonnull NSString *)path bodyParams:(id)bodyParams completion:(nonnull TSCRequestCompletionHandler)completion
 {
-    return [self patch:path withURLParamDictionary:nil bodyParams:bodyParams completion:completion];
+	return [self patch:path withURLParamDictionary:nil bodyParams:bodyParams completion:completion];
 }
 
 - (nonnull TSCRequest *)patch:(nonnull NSString *)path withURLParamDictionary:(nullable NSDictionary *)URLParamDictionary bodyParams:(id)bodyParams completion:(nonnull TSCRequestCompletionHandler)completion
 {
-    return [self patch:path withURLParamDictionary:URLParamDictionary bodyParams:bodyParams contentType:TSCRequestContentTypeJSON completion:completion];
+	return [self patch:path withURLParamDictionary:URLParamDictionary bodyParams:bodyParams contentType:TSCRequestContentTypeJSON completion:completion];
 }
 
 - (nonnull TSCRequest *)patch:(nonnull NSString *)path withURLParamDictionary:(nullable NSDictionary *)URLParamDictionary bodyParams:(id)bodyParams contentType:(TSCRequestContentType)contentType completion:(nonnull TSCRequestCompletionHandler)completion
 {
-    TSCRequest *request = [TSCRequest new];
-    request.baseURL = self.sharedBaseURL;
-    request.path = path;
-    request.requestHTTPMethod = TSCRequestHTTPMethodPATCH;
-    request.bodyParameters = bodyParams;
-    request.URLParameterDictionary = URLParamDictionary;
-    request.contentType = contentType;
-    request.requestHeaders = self.sharedRequestHeaders;
-    
-    [self scheduleRequest:request completion:completion];
-    return request;
+	TSCRequest *request = [TSCRequest new];
+	request.baseURL = self.sharedBaseURL;
+	request.path = path;
+	request.requestHTTPMethod = TSCRequestHTTPMethodPATCH;
+	request.bodyParameters = bodyParams;
+	request.URLParameterDictionary = URLParamDictionary;
+	request.contentType = contentType;
+	request.requestHeaders = self.sharedRequestHeaders;
+	
+	[self scheduleRequest:request completion:completion];
+	return request;
 }
 
 #pragma mark - DELETE Requests
 
 - (nonnull TSCRequest *)delete:(nonnull NSString *)path completion:(nonnull TSCRequestCompletionHandler)completion
 {
-    return [self delete:path withURLParamDictionary:nil completion:completion];
+	return [self delete:path withURLParamDictionary:nil completion:completion];
 }
 
 - (nonnull TSCRequest *)delete:(nonnull NSString *)path withURLParamDictionary:(nullable NSDictionary *)URLParamDictionary completion:(nonnull TSCRequestCompletionHandler)completion
 {
-    TSCRequest *request = [TSCRequest new];
-    request.baseURL = self.sharedBaseURL;
-    request.requestHTTPMethod = TSCRequestHTTPMethodDELETE;
-    request.path = path;
-    request.URLParameterDictionary = URLParamDictionary;
-    request.requestHeaders = self.sharedRequestHeaders;
-
-    [self scheduleRequest:request completion:completion];
-    return request;
+	TSCRequest *request = [TSCRequest new];
+	request.baseURL = self.sharedBaseURL;
+	request.requestHTTPMethod = TSCRequestHTTPMethodDELETE;
+	request.path = path;
+	request.URLParameterDictionary = URLParamDictionary;
+	request.requestHeaders = self.sharedRequestHeaders;
+	
+	[self scheduleRequest:request completion:completion];
+	return request;
 }
 
 #pragma mark - HEAD Requests
 
 - (nonnull TSCRequest *)head:(nonnull NSString *)path withURLParamDictionary:(nullable NSDictionary *)URLParamDictionary completion:(nonnull TSCRequestCompletionHandler)completion
 {
-    TSCRequest *request = [TSCRequest new];
-    request.baseURL = self.sharedBaseURL;
-    request.requestHTTPMethod = TSCRequestHTTPMethodHEAD;
-    request.path = path;
-    request.URLParameterDictionary = URLParamDictionary;
-    request.requestHeaders = self.sharedRequestHeaders;
-
-    [self scheduleRequest:request completion:completion];
-    return request;
+	TSCRequest *request = [TSCRequest new];
+	request.baseURL = self.sharedBaseURL;
+	request.requestHTTPMethod = TSCRequestHTTPMethodHEAD;
+	request.path = path;
+	request.URLParameterDictionary = URLParamDictionary;
+	request.requestHeaders = self.sharedRequestHeaders;
+	
+	[self scheduleRequest:request completion:completion];
+	return request;
 }
 
 #pragma mark - DOWNLOAD/UPLOAD Requests
 
 - (void)downloadFileWithPath:(nonnull NSString *)path progress:(nullable TSCRequestProgressHandler)progress completion:(nonnull TSCRequestTransferCompletionHandler)completion
 {
-    TSCRequest *request = [TSCRequest new];
-    request.baseURL = self.sharedBaseURL;
-    request.path = path;
-    request.requestHTTPMethod = TSCRequestHTTPMethodGET;
-    request.requestHeaders = self.sharedRequestHeaders;
-
-    [self scheduleDownloadRequest:request progress:progress completion:completion];
+	TSCRequest *request = [TSCRequest new];
+	request.baseURL = self.sharedBaseURL;
+	request.path = path;
+	request.requestHTTPMethod = TSCRequestHTTPMethodGET;
+	request.requestHeaders = self.sharedRequestHeaders;
+	
+	[self scheduleDownloadRequest:request progress:progress completion:completion];
 }
 
 - (void)uploadFileFromPath:(nonnull NSString *)filePath toPath:(nonnull NSString *)path progress:(nullable TSCRequestProgressHandler)progress completion:(nonnull TSCRequestTransferCompletionHandler)completion
 {
-    TSCRequest *request = [TSCRequest new];
-    request.baseURL = self.sharedBaseURL;
-    request.path = path;
-    request.requestHTTPMethod = TSCRequestHTTPMethodPOST;
-    request.requestHeaders = self.sharedRequestHeaders;
-    
-    [self scheduleUploadRequest:request filePath:filePath progress:progress completion:completion];
+	TSCRequest *request = [TSCRequest new];
+	request.baseURL = self.sharedBaseURL;
+	request.path = path;
+	request.requestHTTPMethod = TSCRequestHTTPMethodPOST;
+	request.requestHeaders = self.sharedRequestHeaders;
+	
+	[self scheduleUploadRequest:request filePath:filePath progress:progress completion:completion];
 }
 
 - (void)uploadFileData:(nonnull NSData *)fileData toPath:(nonnull NSString *)path progress:(nullable TSCRequestProgressHandler)progress completion:(nonnull TSCRequestTransferCompletionHandler)completion
 {
-    TSCRequest *request = [TSCRequest new];
-    request.baseURL = self.sharedBaseURL;
-    request.path = path;
-    request.requestHTTPMethod = TSCRequestHTTPMethodPOST;
-    request.requestHeaders = self.sharedRequestHeaders;
-    request.HTTPBody = fileData;
-    
-    NSString *cachesDirectory = [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) lastObject];
-
-    NSString *filePathString = [cachesDirectory stringByAppendingPathComponent:[[NSUUID UUID] UUIDString]];
-    [fileData writeToFile:filePathString atomically:YES];
-    
-    [self scheduleUploadRequest:request filePath:filePathString progress:progress completion:completion];
+	TSCRequest *request = [TSCRequest new];
+	request.baseURL = self.sharedBaseURL;
+	request.path = path;
+	request.requestHTTPMethod = TSCRequestHTTPMethodPOST;
+	request.requestHeaders = self.sharedRequestHeaders;
+	request.HTTPBody = fileData;
+	
+	NSString *cachesDirectory = [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) lastObject];
+	
+	NSString *filePathString = [cachesDirectory stringByAppendingPathComponent:[[NSUUID UUID] UUIDString]];
+	[fileData writeToFile:filePathString atomically:YES];
+	
+	[self scheduleUploadRequest:request filePath:filePathString progress:progress completion:completion];
 }
 
 - (void)uploadFileData:(nonnull NSData *)fileData toPath:(nonnull NSString *)path contentType:(TSCRequestContentType)type progress:(nullable TSCRequestProgressHandler)progress completion:(nonnull TSCRequestTransferCompletionHandler)completion
 {
-    TSCRequest *request = [TSCRequest new];
-    request.baseURL = self.sharedBaseURL;
-    request.path = path;
-    request.requestHTTPMethod = TSCRequestHTTPMethodPOST;
-    request.requestHeaders = self.sharedRequestHeaders;
-    request.contentType = type;
-    request.HTTPBody = fileData;
-    
-    NSString *cachesDirectory = [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) lastObject];
-    
-    NSString *filePathString = [cachesDirectory stringByAppendingPathComponent:[[NSUUID UUID] UUIDString]];
-    [fileData writeToFile:filePathString atomically:YES];
-    
-    [self scheduleUploadRequest:request filePath:filePathString progress:progress completion:completion];
+	TSCRequest *request = [TSCRequest new];
+	request.baseURL = self.sharedBaseURL;
+	request.path = path;
+	request.requestHTTPMethod = TSCRequestHTTPMethodPOST;
+	request.requestHeaders = self.sharedRequestHeaders;
+	request.contentType = type;
+	request.HTTPBody = fileData;
+	
+	NSString *cachesDirectory = [NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) lastObject];
+	
+	NSString *filePathString = [cachesDirectory stringByAppendingPathComponent:[[NSUUID UUID] UUIDString]];
+	[fileData writeToFile:filePathString atomically:YES];
+	
+	[self scheduleUploadRequest:request filePath:filePathString progress:progress completion:completion];
 }
 
 - (void)uploadBodyParams:(nullable NSDictionary *)bodyParams toPath:(nonnull NSString *)path contentType:(TSCRequestContentType)type progress:(nullable TSCRequestProgressHandler)progress completion:(nonnull TSCRequestTransferCompletionHandler)completion
 {
-    TSCRequest *request = [TSCRequest new];
-    request.baseURL = self.sharedBaseURL;
-    request.path = path;
-    request.requestHTTPMethod = TSCRequestHTTPMethodPOST;
-    request.requestHeaders = self.sharedRequestHeaders;
-    request.contentType = type;
-    request.bodyParameters = bodyParams;
-    
-    [self scheduleUploadRequest:request filePath:nil progress:progress completion:completion];
-    
+	TSCRequest *request = [TSCRequest new];
+	request.baseURL = self.sharedBaseURL;
+	request.path = path;
+	request.requestHTTPMethod = TSCRequestHTTPMethodPOST;
+	request.requestHeaders = self.sharedRequestHeaders;
+	request.contentType = type;
+	request.bodyParameters = bodyParams;
+	
+	[self scheduleUploadRequest:request filePath:nil progress:progress completion:completion];
 }
 
 - (void)TSC_fireRequestCompletionWithData:(NSData *)data response:(NSURLResponse *)response error:(NSError *)error request:(TSCRequest *)request completion:(TSCRequestCompletionHandler)completion onThread:(NSThread *)scheduleThread
 {
-    TSCRequestResponse *requestResponse = [[TSCRequestResponse alloc] initWithResponse:response data:data];
-    
-    if (request.taskIdentifier && self.redirectResponses[@(request.taskIdentifier)]) {
-        requestResponse.redirectResponse = self.redirectResponses[@(request.taskIdentifier)];
-        [self.redirectResponses removeObjectForKey:@(request.taskIdentifier)];
-    }
-    
-    NSMutableDictionary *requestInfo = [NSMutableDictionary new];
-    if (request) {
-        requestInfo[TSCRequestNotificationRequestKey] = request;
-    }
-    if (response) {
-        requestInfo[TSCRequestNotificationResponseKey] = requestResponse;
-    }
-    
-    //Notify of response
-    [[NSNotificationCenter defaultCenter] postNotificationName:TSCRequestDidReceiveResponse object:requestResponse userInfo:requestInfo];
-    
-    //Notify of errors
-    if ([self statusCodeIsConsideredHTTPError:requestResponse.status]) {
-        
-        [[NSNotificationCenter defaultCenter] postNotificationName:TSCRequestServerError object:requestResponse userInfo:requestInfo];
-        
-    }
-    
-    if (error || [self statusCodeIsConsideredHTTPError:requestResponse.status]) {
-        
-        TSCErrorRecoveryAttempter *recoveryAttempter = [TSCErrorRecoveryAttempter new];
-        
-        [recoveryAttempter addOption:[TSCErrorRecoveryOption optionWithTitle:@"Retry" type:TSCErrorRecoveryOptionTypeRetry handler:^(TSCErrorRecoveryOption *option) {
-            
-            [self scheduleRequest:request completion:completion];
-            
-        }]];
-        
-        [recoveryAttempter addOption:[TSCErrorRecoveryOption optionWithTitle:@"Cancel" type:TSCErrorRecoveryOptionTypeCancel handler:nil]];
-        
-        [scheduleThread performBlock:^{
-            
-            if (error) {
-                completion(requestResponse, [recoveryAttempter recoverableErrorWithError:error]);
-            } else {
-                
-                NSError *httpError = [NSError errorWithDomain:TSCRequestErrorDomain code:requestResponse.status userInfo:@{NSLocalizedDescriptionKey: [NSHTTPURLResponse localizedStringForStatusCode:requestResponse.status]}];
-                completion(requestResponse, [recoveryAttempter recoverableErrorWithError:httpError]);
-                
-            }
-        }];
-        
-    } else {
-        
-        [scheduleThread performBlock:^{
-            completion(requestResponse, error);
-        }];
-        
-    }
-    
-    //Log
-    if (self.verboseLogging) {
-        
-        if (error) {
-            
-            NSLog(@"Request:%@", request);
-            NSLog(@"\n<ThunderRequest>\nURL: %@\nMethod: %@\nRequest Headers:%@\nBody: %@\n\nResponse Status: FAILURE \nError Description: %@",request.URL, request.HTTPMethod, request.allHTTPHeaderFields, [[NSString alloc] initWithData:request.HTTPBody encoding:NSUTF8StringEncoding], error.localizedDescription);
-        } else {
-            
-            [scheduleThread performBlock:^{
-                
-                NSRange truncatedRange = {0, MIN(requestResponse.string.length, 25)};
-                truncatedRange = [requestResponse.string rangeOfComposedCharacterSequencesForRange:truncatedRange];
-                
-                NSLog(@"\n<ThunderRequest>\nURL:    %@\nMethod: %@\nRequest Headers:%@\nBody: %@\n\nResponse Status: %li\nResponse Body: %@\n",request.URL, request.HTTPMethod, request.allHTTPHeaderFields, [[NSString alloc] initWithData:request.HTTPBody encoding:NSUTF8StringEncoding], (long)requestResponse.status, self.truncatesVerboseResponse ? [[requestResponse.string substringWithRange:truncatedRange] stringByAppendingString:@"..."] : requestResponse.string);
-            }];
-            
-        }
-    }
+	TSCRequestResponse *requestResponse = [[TSCRequestResponse alloc] initWithResponse:response data:data];
+	
+	if (request.taskIdentifier && self.redirectResponses[@(request.taskIdentifier)]) {
+		requestResponse.redirectResponse = self.redirectResponses[@(request.taskIdentifier)];
+		[self.redirectResponses removeObjectForKey:@(request.taskIdentifier)];
+	}
+	
+	NSMutableDictionary *requestInfo = [NSMutableDictionary new];
+	if (request) {
+		requestInfo[TSCRequestNotificationRequestKey] = request;
+	}
+	if (response) {
+		requestInfo[TSCRequestNotificationResponseKey] = requestResponse;
+	}
+	
+	//Notify of response
+	[[NSNotificationCenter defaultCenter] postNotificationName:TSCRequestDidReceiveResponse object:requestResponse userInfo:requestInfo];
+	
+	//Notify of errors
+	if ([self statusCodeIsConsideredHTTPError:requestResponse.status]) {
+		[[NSNotificationCenter defaultCenter] postNotificationName:TSCRequestServerError object:requestResponse userInfo:requestInfo];
+	}
+	
+	if (error || [self statusCodeIsConsideredHTTPError:requestResponse.status]) {
+		
+		TSCErrorRecoveryAttempter *recoveryAttempter = [TSCErrorRecoveryAttempter new];
+		
+		[recoveryAttempter addOption:[TSCErrorRecoveryOption optionWithTitle:@"Retry" type:TSCErrorRecoveryOptionTypeRetry handler:^(TSCErrorRecoveryOption *option) {
+			
+			[self scheduleRequest:request completion:completion];
+			
+		}]];
+		
+		[recoveryAttempter addOption:[TSCErrorRecoveryOption optionWithTitle:@"Cancel" type:TSCErrorRecoveryOptionTypeCancel handler:nil]];
+		
+		[scheduleThread performBlock:^{
+			
+			if (error) {
+				completion(requestResponse, [recoveryAttempter recoverableErrorWithError:error]);
+			} else {
+				
+				NSError *httpError = [NSError errorWithDomain:TSCRequestErrorDomain code:requestResponse.status userInfo:@{NSLocalizedDescriptionKey: [NSHTTPURLResponse localizedStringForStatusCode:requestResponse.status]}];
+				completion(requestResponse, [recoveryAttempter recoverableErrorWithError:httpError]);
+			}
+		}];
+		
+	} else {
+		
+		[scheduleThread performBlock:^{
+			completion(requestResponse, error);
+		}];
+	}
+	
+	//Log
+	if (self.verboseLogging) {
+		
+		if (error) {
+			
+			NSLog(@"Request:%@", request);
+			NSLog(@"\n<ThunderRequest>\nURL: %@\nMethod: %@\nRequest Headers:%@\nBody: %@\n\nResponse Status: FAILURE \nError Description: %@",request.URL, request.HTTPMethod, request.allHTTPHeaderFields, [[NSString alloc] initWithData:request.HTTPBody encoding:NSUTF8StringEncoding], error.localizedDescription);
+		} else {
+			
+			[scheduleThread performBlock:^{
+				
+				NSRange truncatedRange = {0, MIN(requestResponse.string.length, 25)};
+				truncatedRange = [requestResponse.string rangeOfComposedCharacterSequencesForRange:truncatedRange];
+				
+				NSLog(@"\n<ThunderRequest>\nURL:    %@\nMethod: %@\nRequest Headers:%@\nBody: %@\n\nResponse Status: %li\nResponse Body: %@\n",request.URL, request.HTTPMethod, request.allHTTPHeaderFields, [[NSString alloc] initWithData:request.HTTPBody encoding:NSUTF8StringEncoding], (long)requestResponse.status, self.truncatesVerboseResponse ? [[requestResponse.string substringWithRange:truncatedRange] stringByAppendingString:@"..."] : requestResponse.string);
+			}];
+		}
+	}
 }
 
 #pragma mark - Request scheduling
@@ -444,426 +438,428 @@ typedef void (^TSCOAuth2CheckCompletion) (BOOL authenticated, NSError *authError
 // This method is used to check the OAuth2 status before starting a request
 - (void)checkOAuthStatusWithRequest:(TSCRequest *)request completion:(TSCOAuth2CheckCompletion)completion
 {
-    // If we have an OAuth2 delegate and the request isn't the request to refresh our token
-    if (self.OAuth2Delegate) {
-        
-        if (!self.sharedRequestCredential || ![self.sharedRequestCredential isKindOfClass:[TSCOAuth2Credential class]]) {
-            self.sharedRequestCredential = [TSCOAuth2Credential retrieveCredentialWithIdentifier:[self.OAuth2Delegate authIdentifier]];
-        }
-        
-        // If we got shared credentials and they are OAuth 2 credentials we can continue
-        if (self.sharedRequestCredential && [self.sharedRequestCredential isKindOfClass:[TSCOAuth2Credential class]]) {
-            
-            TSCOAuth2Credential *OAuth2Credential = (TSCOAuth2Credential *)self.sharedRequestCredential;
-            
-            // If our credentials have expired, and we don't already have a re-authentication request let's ask our delegate to refresh them
-            if (OAuth2Credential.hasExpired && !self.reAuthenticating) {
-                
-                __weak typeof(self) welf = self;
-                
-                // Important so if the re-authenticating call uses this request controller we don't end up in an infinite loop! :P (My bad guys! (Simon))
-                self.reAuthenticating = true;
-                
-                [self.OAuth2Delegate reAuthenticateCredential:OAuth2Credential withCompletion:^(TSCOAuth2Credential * __nullable credential, NSError * __nullable error, BOOL saveToKeychain) {
-                    
-                    // If we don't get an error we save the credentials to the keychain and then call the completion block
-                    if (!error) {
-                        
-                        if (saveToKeychain) {
-                            [TSCOAuth2Credential storeCredential:credential withIdentifier:[welf.OAuth2Delegate authIdentifier]];
-                        }
-                        welf.sharedRequestCredential = credential;
-                    }
-                    
-                    // Call back to the initial OAuth check
-                    if (completion) {
-                        completion(error == nil, error, false);
-                    }
-                    
-                    // Re-schedule any requests that were queued whilst we were refreshing the OAuth token
-                    for (NSDictionary *request in welf.authQueuedRequests.copy) {
-                        [welf scheduleRequest:request[TSCQueuedRequestKey] completion:request[TSCQueuedCompletionKey]];
-                    }
-                    
-                    welf.authQueuedRequests = [NSMutableArray new];
-                    welf.reAuthenticating = false;
-                    
-                }];
-                
-            } else if (self.reAuthenticating) { // The OAuth2 token has expired, but this is not the request which will refresh it, this can optionally be queued by the user
-                
-                completion(false, nil, true);
-                
-            } else {
-                
-                completion(true, nil, false);
-            }
-        } else {
-            completion(true, nil, false);
-        }
-    } else {
-        
-        if (completion) {
-            completion(true, nil, false);
-        }
-    }
+	// If we have an OAuth2 delegate and the request isn't the request to refresh our token
+	if (self.OAuth2Delegate) {
+		
+		if (!self.sharedRequestCredential || ![self.sharedRequestCredential isKindOfClass:[TSCOAuth2Credential class]]) {
+			self.sharedRequestCredential = [TSCOAuth2Credential retrieveCredentialWithIdentifier:[self.OAuth2Delegate authIdentifier]];
+		}
+		
+		// If we got shared credentials and they are OAuth 2 credentials we can continue
+		if (self.sharedRequestCredential && [self.sharedRequestCredential isKindOfClass:[TSCOAuth2Credential class]]) {
+			
+			TSCOAuth2Credential *OAuth2Credential = (TSCOAuth2Credential *)self.sharedRequestCredential;
+			
+			// If our credentials have expired, and we don't already have a re-authentication request let's ask our delegate to refresh them
+			if (OAuth2Credential.hasExpired && !self.reAuthenticating) {
+				
+				__weak typeof(self) welf = self;
+				
+				// Important so if the re-authenticating call uses this request controller we don't end up in an infinite loop! :P (My bad guys! (Simon))
+				self.reAuthenticating = true;
+				
+				[self.OAuth2Delegate reAuthenticateCredential:OAuth2Credential withCompletion:^(TSCOAuth2Credential * __nullable credential, NSError * __nullable error, BOOL saveToKeychain) {
+					
+					// If we don't get an error we save the credentials to the keychain and then call the completion block
+					if (!error) {
+						
+						if (saveToKeychain) {
+							[TSCOAuth2Credential storeCredential:credential withIdentifier:[welf.OAuth2Delegate authIdentifier]];
+						}
+						welf.sharedRequestCredential = credential;
+					}
+					
+					// Call back to the initial OAuth check
+					if (completion) {
+						completion(error == nil, error, false);
+					}
+					
+					// Re-schedule any requests that were queued whilst we were refreshing the OAuth token
+					for (NSDictionary *request in welf.authQueuedRequests.copy) {
+						[welf scheduleRequest:request[TSCQueuedRequestKey] completion:request[TSCQueuedCompletionKey]];
+					}
+					
+					welf.authQueuedRequests = [NSMutableArray new];
+					welf.reAuthenticating = false;
+				}];
+				
+			} else if (self.reAuthenticating) { // The OAuth2 token has expired, but this is not the request which will refresh it, this can optionally be queued by the user
+				
+				completion(false, nil, true);
+				
+			} else {
+				
+				completion(true, nil, false);
+			}
+			
+		} else {
+			
+			completion(true, nil, false);
+		}
+		
+	} else {
+		
+		if (completion) {
+			completion(true, nil, false);
+		}
+	}
 }
 
 - (void)scheduleDownloadRequest:(TSCRequest *)request progress:(TSCRequestProgressHandler)progress completion:(TSCRequestTransferCompletionHandler)completion
 {
-    __weak typeof(self) welf = self;
-    
-    [self TSC_showApplicationActivity];
-    [request prepareForDispatch];
-    
-    // Check OAuth status before making the request
-    [self checkOAuthStatusWithRequest:request completion:^(BOOL authenticated, NSError *error, BOOL needsQueueing) {
-       
-        if (error || !authenticated) {
-            
-            if (completion) {
-                completion(nil, error);
-            }
-            return;
-        }
-        
-        if (self.runSynchronously) {
-            
-            NSError *error = nil;
-            NSURL *url = [welf.backgroundSession sendSynchronousDownloadTaskWithURL:request.URL returningResponse:nil error:&error];
-            
-            [self TSC_hideApplicationActivity];
-            
-            if (completion) {
-                completion(url, error);
-            }
-            
-        } else {
-            
-            NSURLRequest *normalisedRequest = [self backgroundableRequestObjectFromTSCRequest:request];
-            NSURLSessionDownloadTask *task = [welf.backgroundSession downloadTaskWithRequest:normalisedRequest];
-            
-            [welf addCompletionHandler:completion progressHandler:progress forTaskIdentifier:task.taskIdentifier];
-            [task resume];
-            
-        }
-    }];
+	__weak typeof(self) welf = self;
+	
+	[self TSC_showApplicationActivity];
+	[request prepareForDispatch];
+	
+	// Check OAuth status before making the request
+	[self checkOAuthStatusWithRequest:request completion:^(BOOL authenticated, NSError *error, BOOL needsQueueing) {
+		
+		if (error || !authenticated) {
+			
+			if (completion) {
+				completion(nil, error);
+			}
+			return;
+		}
+		
+		if (self.runSynchronously) {
+			
+			NSError *error = nil;
+			NSURL *url = [welf.backgroundSession sendSynchronousDownloadTaskWithURL:request.URL returningResponse:nil error:&error];
+			
+			[self TSC_hideApplicationActivity];
+			
+			if (completion) {
+				completion(url, error);
+			}
+			
+		} else {
+			
+			NSURLRequest *normalisedRequest = [self backgroundableRequestObjectFromTSCRequest:request];
+			NSURLSessionDownloadTask *task = [welf.backgroundSession downloadTaskWithRequest:normalisedRequest];
+			
+			[welf addCompletionHandler:completion progressHandler:progress forTaskIdentifier:task.taskIdentifier];
+			[task resume];
+			
+		}
+	}];
 }
 
 - (void)scheduleUploadRequest:(nonnull TSCRequest *)request filePath:(NSString *)filePath progress:(nullable TSCRequestProgressHandler)progress completion:(nonnull TSCRequestTransferCompletionHandler)completion
 {
-    __weak typeof(self) welf = self;
-    
-    [self TSC_showApplicationActivity];
-    
-    [self checkOAuthStatusWithRequest:request completion:^(BOOL authenticated, NSError *error, BOOL needsQueueing) {
-        
-        if (error || !authenticated) {
-            
-            [self TSC_hideApplicationActivity];
-
-            if (completion) {
-                completion(nil, error);
-            }
-            return;
-        }
-        
-        [request prepareForDispatch];
-        
-        if (self.runSynchronously) {
-            
-            NSError *error = nil;
-            
-            if (request.HTTPBody) {
-                [welf.defaultSession sendSynchronousUploadTaskWithRequest:[welf backgroundableRequestObjectFromTSCRequest:request] fromData:request.HTTPBody returningResponse:nil error:&error];
-            } else {
-                [welf.backgroundSession sendSynchronousUploadTaskWithRequest:[welf backgroundableRequestObjectFromTSCRequest:request] fromFile:[NSURL fileURLWithPath:filePath] returningResponse:nil error:&error];
-            }
-            
-            [self TSC_hideApplicationActivity];
-
-            if (completion) {
-                completion(nil, error);
-            }
-            
-        } else {
-            
-            NSURLSessionUploadTask *task;
-            
-            if (request.HTTPBody) {
-                task = [welf.defaultSession uploadTaskWithRequest:[welf backgroundableRequestObjectFromTSCRequest:request] fromData:request.HTTPBody];
-            } else {
-                
-                task = [welf.backgroundSession uploadTaskWithRequest:[welf backgroundableRequestObjectFromTSCRequest:request] fromFile:[NSURL fileURLWithPath:filePath]];
-            }
-            
-            [welf addCompletionHandler:completion progressHandler:progress forTaskIdentifier:task.taskIdentifier];
-            
-            [task resume];
-            
-        }
-    
-    }];
+	__weak typeof(self) welf = self;
+	
+	[self TSC_showApplicationActivity];
+	
+	[self checkOAuthStatusWithRequest:request completion:^(BOOL authenticated, NSError *error, BOOL needsQueueing) {
+		
+		if (error || !authenticated) {
+			
+			[self TSC_hideApplicationActivity];
+			
+			if (completion) {
+				completion(nil, error);
+			}
+			return;
+		}
+		
+		[request prepareForDispatch];
+		
+		if (self.runSynchronously) {
+			
+			NSError *error = nil;
+			
+			if (request.HTTPBody) {
+				[welf.defaultSession sendSynchronousUploadTaskWithRequest:[welf backgroundableRequestObjectFromTSCRequest:request] fromData:request.HTTPBody returningResponse:nil error:&error];
+			} else {
+				[welf.backgroundSession sendSynchronousUploadTaskWithRequest:[welf backgroundableRequestObjectFromTSCRequest:request] fromFile:[NSURL fileURLWithPath:filePath] returningResponse:nil error:&error];
+			}
+			
+			[self TSC_hideApplicationActivity];
+			
+			if (completion) {
+				completion(nil, error);
+			}
+			
+		} else {
+			
+			NSURLSessionUploadTask *task;
+			
+			if (request.HTTPBody) {
+				task = [welf.defaultSession uploadTaskWithRequest:[welf backgroundableRequestObjectFromTSCRequest:request] fromData:request.HTTPBody];
+			} else {
+				
+				task = [welf.backgroundSession uploadTaskWithRequest:[welf backgroundableRequestObjectFromTSCRequest:request] fromFile:[NSURL fileURLWithPath:filePath]];
+			}
+			
+			[welf addCompletionHandler:completion progressHandler:progress forTaskIdentifier:task.taskIdentifier];
+			
+			[task resume];
+			
+		}
+		
+	}];
 }
 
 - (void)scheduleRequest:(TSCRequest *)request completion:(TSCRequestCompletionHandler)completion
 {
-    // Check OAuth status before making the request
-    __weak typeof(self) welf = self;
-    
-    //Loading (Only if we're the first request)
-    [self TSC_showApplicationActivity];
-
-    NSString *userAgent = [[NSUserDefaults standardUserDefaults] stringForKey:@"TSCUserAgent"];
-    if (userAgent) {
-        [request.requestHeaders setValue:userAgent forKey:@"User-Agent"];
-    }
-    
-    [self checkOAuthStatusWithRequest:request completion:^(BOOL authenticated, NSError *error, BOOL needsQueueing) {
-       
-        if (error && !authenticated && !needsQueueing) {
-            
-            [self TSC_hideApplicationActivity];
-
-            if (completion) {
-                completion(nil, error);
-            }
-            return;
-            
-        } else if (needsQueueing) {
-            
-            // If we're not authenticated but didn't get an error then our request came inbetween calling re-authentication and getting
-            [welf.authQueuedRequests addObject:@{TSCQueuedRequestKey:request,TSCQueuedCompletionKey:completion ? : ^( TSCRequestResponse *response, NSError *error){}}];
-        }
-        
-        [request prepareForDispatch];
-        
-        if (welf.runSynchronously) {
-            
-            NSURLResponse *response = nil;
-            NSError *error = nil;
-            NSData *data = [welf.defaultSession sendSynchronousDataTaskWithRequest:request returningResponse:&response error:&error];
-            [welf TSC_fireRequestCompletionWithData:data response:response error:error request:request completion:completion onThread:[NSThread currentThread]];
-            [self TSC_hideApplicationActivity];
-
-        } else {
-            
-            NSThread *currentThread = [NSThread currentThread];
-            NSURLSessionDataTask *dataTask = [welf.defaultSession dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-                
-                [self TSC_hideApplicationActivity];
-
-                [welf TSC_fireRequestCompletionWithData:data response:response error:error request:request completion:completion onThread:currentThread];
-                
-            }];
-            
-            request.taskIdentifier = dataTask.taskIdentifier;
-            [dataTask resume];
-        }
-    }];
+	// Check OAuth status before making the request
+	__weak typeof(self) welf = self;
+	
+	//Loading (Only if we're the first request)
+	[self TSC_showApplicationActivity];
+	
+	NSString *userAgent = [[NSUserDefaults standardUserDefaults] stringForKey:@"TSCUserAgent"];
+	if (userAgent) {
+		[request.requestHeaders setValue:userAgent forKey:@"User-Agent"];
+	}
+	
+	[self checkOAuthStatusWithRequest:request completion:^(BOOL authenticated, NSError *error, BOOL needsQueueing) {
+		
+		if (error && !authenticated && !needsQueueing) {
+			
+			[self TSC_hideApplicationActivity];
+			
+			if (completion) {
+				completion(nil, error);
+			}
+			return;
+			
+		} else if (needsQueueing) {
+			
+			// If we're not authenticated but didn't get an error then our request came inbetween calling re-authentication and getting
+			[welf.authQueuedRequests addObject:@{TSCQueuedRequestKey:request,TSCQueuedCompletionKey:completion ? : ^( TSCRequestResponse *response, NSError *error){}}];
+		}
+		
+		[request prepareForDispatch];
+		
+		if (welf.runSynchronously) {
+			
+			NSURLResponse *response = nil;
+			NSError *error = nil;
+			NSData *data = [welf.defaultSession sendSynchronousDataTaskWithRequest:request returningResponse:&response error:&error];
+			[welf TSC_fireRequestCompletionWithData:data response:response error:error request:request completion:completion onThread:[NSThread currentThread]];
+			[self TSC_hideApplicationActivity];
+			
+		} else {
+			
+			NSThread *currentThread = [NSThread currentThread];
+			NSURLSessionDataTask *dataTask = [welf.defaultSession dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+				
+				[self TSC_hideApplicationActivity];
+				
+				[welf TSC_fireRequestCompletionWithData:data response:response error:error request:request completion:completion onThread:currentThread];
+				
+			}];
+			
+			request.taskIdentifier = dataTask.taskIdentifier;
+			[dataTask resume];
+		}
+	}];
 }
 
 #pragma mark - NSURLSession challenge handling
 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential *))completionHandler
 {
-    if (challenge.previousFailureCount == 0) {
-        completionHandler(NSURLSessionAuthChallengeUseCredential, self.sharedRequestCredential.credential);
-        return;
-    }
-    
-    completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
+	if (challenge.previousFailureCount == 0) {
+		completionHandler(NSURLSessionAuthChallengeUseCredential, self.sharedRequestCredential.credential);
+		return;
+	}
+	
+	completionHandler(NSURLSessionAuthChallengePerformDefaultHandling, nil);
 }
 
 - (void)URLSession:(NSURLSession *)session task:(nonnull NSURLSessionTask *)task willPerformHTTPRedirection:(nonnull NSHTTPURLResponse *)response newRequest:(nonnull NSURLRequest *)request completionHandler:(nonnull void (^)(NSURLRequest * _Nullable))completionHandler
 {
-    self.redirectResponses[@(task.taskIdentifier)] = response;
-    completionHandler(request);
+	self.redirectResponses[@(task.taskIdentifier)] = response;
+	completionHandler(request);
 }
 
 #pragma mark - NSURLSessionDownloadDelegate
 
 - (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didWriteData:(int64_t)bytesWritten totalBytesWritten:(int64_t)totalBytesWritten totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite
 {
-    CGFloat progress = (float)((float)totalBytesWritten /(float)totalBytesExpectedToWrite);
-    
-    [self callProgressHandlerForTaskIdentifier:downloadTask.taskIdentifier progress:progress totalBytes:(NSInteger)totalBytesExpectedToWrite progressBytes:(NSInteger)totalBytesWritten];
+	CGFloat progress = (float)((float)totalBytesWritten /(float)totalBytesExpectedToWrite);
+	
+	[self callProgressHandlerForTaskIdentifier:downloadTask.taskIdentifier progress:progress totalBytes:(NSInteger)totalBytesExpectedToWrite progressBytes:(NSInteger)totalBytesWritten];
 }
 
 - (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didFinishDownloadingToURL:(NSURL *)location
 {
-    [self callCompletionHandlerForTaskIdentifier:downloadTask.taskIdentifier downloadedFileURL:location downloadError:nil];
+	[self callCompletionHandlerForTaskIdentifier:downloadTask.taskIdentifier downloadedFileURL:location downloadError:nil];
 }
 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error
 {
-    [self callCompletionHandlerForTaskIdentifier:task.taskIdentifier downloadedFileURL:nil downloadError:error];
+	[self callCompletionHandlerForTaskIdentifier:task.taskIdentifier downloadedFileURL:nil downloadError:error];
 }
 
 #pragma mark - NSURLSessionUploadDelegate
 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didSendBodyData:(int64_t)bytesSent totalBytesSent:(int64_t)totalBytesSent totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend
 {
-    CGFloat progress = (float)((float)totalBytesSent /(float)totalBytesExpectedToSend);
-    [self callProgressHandlerForTaskIdentifier:task.taskIdentifier progress:progress totalBytes:(NSInteger)totalBytesExpectedToSend progressBytes:(NSInteger)totalBytesSent];
+	CGFloat progress = (float)((float)totalBytesSent /(float)totalBytesExpectedToSend);
+	[self callProgressHandlerForTaskIdentifier:task.taskIdentifier progress:progress totalBytes:(NSInteger)totalBytesExpectedToSend progressBytes:(NSInteger)totalBytesSent];
 }
 
 #pragma mark - NSURLSessionDownload completion handling
 
 - (void)addCompletionHandler:(TSCRequestTransferCompletionHandler)handler progressHandler:(TSCRequestProgressHandler)progress forTaskIdentifier:(NSUInteger)identifier
 {
-    NSString *taskIdentifierString = [NSString stringWithFormat:@"%lu-completion", (unsigned long)identifier];
-    NSString *taskProgressIdentifierString = [NSString stringWithFormat:@"%lu-progress", (unsigned long)identifier];
-    
-    if ([self.completionHandlerDictionary objectForKey:taskIdentifierString]) {
-        NSLog(@"Error: Got multiple handlers for a single task identifier.  This should not happen.\n");
-    }
-    
-    [self.completionHandlerDictionary setObject:handler forKey:taskIdentifierString];
-    
-    if ([self.completionHandlerDictionary objectForKey:taskProgressIdentifierString]) {
-        NSLog(@"Error: Got multiple progress handlers for a single task identifier.  This should not happen.\n");
-    }
-    
-    [self.completionHandlerDictionary setObject:progress forKey:taskProgressIdentifierString];
+	NSString *taskIdentifierString = [NSString stringWithFormat:@"%lu-completion", (unsigned long)identifier];
+	NSString *taskProgressIdentifierString = [NSString stringWithFormat:@"%lu-progress", (unsigned long)identifier];
+	
+	if ([self.completionHandlerDictionary objectForKey:taskIdentifierString]) {
+		NSLog(@"Error: Got multiple handlers for a single task identifier.  This should not happen.\n");
+	}
+	
+	[self.completionHandlerDictionary setObject:handler forKey:taskIdentifierString];
+	
+	if ([self.completionHandlerDictionary objectForKey:taskProgressIdentifierString]) {
+		NSLog(@"Error: Got multiple progress handlers for a single task identifier.  This should not happen.\n");
+	}
+	
+	[self.completionHandlerDictionary setObject:progress forKey:taskProgressIdentifierString];
 }
 
 - (void)callCompletionHandlerForTaskIdentifier:(NSUInteger)identifier downloadedFileURL:(NSURL *)fileURL downloadError:(NSError *)error
 {
-    NSString *taskIdentifierString = [NSString stringWithFormat:@"%lu-completion", (unsigned long)identifier];
-    NSString *taskProgressIdentifierString = [NSString stringWithFormat:@"%lu-progress", (unsigned long)identifier];
-
-    [self TSC_hideApplicationActivity];
-
-    TSCRequestTransferCompletionHandler handler = [self.completionHandlerDictionary objectForKey:taskIdentifierString];
-    
-    if (handler) {
-        
-        [self.completionHandlerDictionary removeObjectsForKeys:@[taskIdentifierString, taskProgressIdentifierString]];
-        
-        handler(fileURL, error);
-        
-    }
+	NSString *taskIdentifierString = [NSString stringWithFormat:@"%lu-completion", (unsigned long)identifier];
+	NSString *taskProgressIdentifierString = [NSString stringWithFormat:@"%lu-progress", (unsigned long)identifier];
+	
+	[self TSC_hideApplicationActivity];
+	
+	TSCRequestTransferCompletionHandler handler = [self.completionHandlerDictionary objectForKey:taskIdentifierString];
+	
+	if (handler) {
+		
+		[self.completionHandlerDictionary removeObjectsForKeys:@[taskIdentifierString, taskProgressIdentifierString]];
+		
+		handler(fileURL, error);
+		
+	}
 }
 
 - (void)callProgressHandlerForTaskIdentifier:(NSUInteger)identifier progress:(CGFloat)progress totalBytes:(NSInteger)total progressBytes:(NSInteger)bytes
 {
-    NSString *taskProgressIdentifierString = [NSString stringWithFormat:@"%lu-progress", (unsigned long)identifier];
-    
-    TSCRequestProgressHandler handler = [self.completionHandlerDictionary objectForKey:taskProgressIdentifierString];
-    
-    if (handler) {
-        
-        handler(progress, total, bytes);
-        
-    }
-
+	NSString *taskProgressIdentifierString = [NSString stringWithFormat:@"%lu-progress", (unsigned long)identifier];
+	
+	TSCRequestProgressHandler handler = [self.completionHandlerDictionary objectForKey:taskProgressIdentifierString];
+	
+	if (handler) {
+		
+		handler(progress, total, bytes);
+		
+	}
+	
 }
 
 #pragma mark - Error handling
 
 - (BOOL)statusCodeIsConsideredHTTPError:(NSInteger)statusCode
 {
-    if (statusCode >= 400 && statusCode < 600) {
-        
-        return true;
-    }
-    
-    return false;
+	if (statusCode >= 400 && statusCode < 600) {
+		
+		return true;
+	}
+	
+	return false;
 }
 
 #pragma mark - OAuth2 Flow
 
 - (void)setOAuth2Delegate:(id<TSCOAuth2Manager>)OAuth2Delegate
 {
-    _OAuth2Delegate = OAuth2Delegate;
-    
-    if (!OAuth2Delegate) {
-        self.OAuth2RequestController = nil;
-    }
-    
-    if (!OAuth2Delegate) {
-        return;
-    }
-    
-    TSCOAuth2Credential *credential = (TSCOAuth2Credential *)[TSCOAuth2Credential retrieveCredentialWithIdentifier:[OAuth2Delegate authIdentifier]];
-    if (credential) {
-        self.sharedRequestCredential = credential;
-    }
+	_OAuth2Delegate = OAuth2Delegate;
+	
+	if (!OAuth2Delegate) {
+		self.OAuth2RequestController = nil;
+	}
+	
+	if (!OAuth2Delegate) {
+		return;
+	}
+	
+	TSCOAuth2Credential *credential = (TSCOAuth2Credential *)[TSCOAuth2Credential retrieveCredentialWithIdentifier:[OAuth2Delegate authIdentifier]];
+	if (credential) {
+		self.sharedRequestCredential = credential;
+	}
 }
 
 - (TSCRequestController *)OAuth2RequestController
 {
-    if (!_OAuth2RequestController) {
-        _OAuth2RequestController = [[TSCRequestController alloc] initWithBaseURL:self.sharedBaseURL];
-    }
-    
-    return _OAuth2RequestController;
+	if (!_OAuth2RequestController) {
+		_OAuth2RequestController = [[TSCRequestController alloc] initWithBaseURL:self.sharedBaseURL];
+	}
+	
+	return _OAuth2RequestController;
 }
 
 - (void)setSharedRequestCredential:(TSCRequestCredential *)credential andSaveToKeychain:(BOOL)save
 {
-    _sharedRequestCredential = credential;
-    
-    if ([_sharedRequestCredential isKindOfClass:[TSCOAuth2Credential class]]) {
-        
-        TSCOAuth2Credential *OAuthCredential = (TSCOAuth2Credential *)_sharedRequestCredential;
-        self.sharedRequestHeaders[@"Authorization"] = [NSString stringWithFormat:@"%@ %@", OAuthCredential.tokenType, OAuthCredential.authorizationToken];
-    }
-    
-    if (save) {
-        [[credential class] storeCredential:credential withIdentifier: self.OAuth2Delegate ? [self.OAuth2Delegate authIdentifier] : [NSString stringWithFormat:@"thundertable.com.threesidedcube-%@", self.sharedBaseURL]];
-    }
+	_sharedRequestCredential = credential;
+	
+	if ([_sharedRequestCredential isKindOfClass:[TSCOAuth2Credential class]]) {
+		
+		TSCOAuth2Credential *OAuthCredential = (TSCOAuth2Credential *)_sharedRequestCredential;
+		self.sharedRequestHeaders[@"Authorization"] = [NSString stringWithFormat:@"%@ %@", OAuthCredential.tokenType, OAuthCredential.authorizationToken];
+	}
+	
+	if (save) {
+		[[credential class] storeCredential:credential withIdentifier: self.OAuth2Delegate ? [self.OAuth2Delegate authIdentifier] : [NSString stringWithFormat:@"thundertable.com.threesidedcube-%@", self.sharedBaseURL]];
+	}
 }
 
 - (void)setSharedRequestCredential:(TSCRequestCredential *)sharedRequestCredential
 {
-    [self setSharedRequestCredential:sharedRequestCredential andSaveToKeychain:false];
+	[self setSharedRequestCredential:sharedRequestCredential andSaveToKeychain:false];
 }
 
 - (void)URLSessionDidFinishEventsForBackgroundURLSession:(NSURLSession *)session
 {
-    NSLog(@"finihed events for bg session");
+	NSLog(@"finihed events for bg session");
 }
 
 #pragma mark - Request conversion
 
 - (NSMutableURLRequest *)backgroundableRequestObjectFromTSCRequest:(TSCRequest *)tscRequest
 {
-    NSMutableURLRequest *backgroundableRequest = [NSMutableURLRequest new];
-    backgroundableRequest.URL = tscRequest.URL;
-    backgroundableRequest.HTTPMethod = [tscRequest stringForHTTPMethod:tscRequest.requestHTTPMethod];
-    backgroundableRequest.HTTPBody = tscRequest.HTTPBody;
-    
-    for (NSString *key in [tscRequest.requestHeaders allKeys]) {
-        [backgroundableRequest setValue:tscRequest.requestHeaders[key] forHTTPHeaderField:key];
-    }
-    
-    return backgroundableRequest;
+	NSMutableURLRequest *backgroundableRequest = [NSMutableURLRequest new];
+	backgroundableRequest.URL = tscRequest.URL;
+	backgroundableRequest.HTTPMethod = [tscRequest stringForHTTPMethod:tscRequest.requestHTTPMethod];
+	backgroundableRequest.HTTPBody = tscRequest.HTTPBody;
+	
+	for (NSString *key in [tscRequest.requestHeaders allKeys]) {
+		[backgroundableRequest setValue:tscRequest.requestHeaders[key] forHTTPHeaderField:key];
+	}
+	
+	return backgroundableRequest;
 }
 
 - (void)invalidateAndCancel
 {
-    [self.defaultSession invalidateAndCancel];
-    [self.backgroundSession invalidateAndCancel];
-    [self.ephemeralSession invalidateAndCancel];
+	[self.defaultSession invalidateAndCancel];
+	[self.backgroundSession invalidateAndCancel];
+	[self.ephemeralSession invalidateAndCancel];
 }
 
 - (void)TSC_showApplicationActivity
 {
 #if TARGET_OS_IOS
-    if (![[[NSBundle mainBundle] objectForInfoDictionaryKey:@"TSCThunderRequestShouldHideActivityIndicator"] boolValue]) {
-        [ApplicationLoadingIndicatorManager.sharedManager showActivityIndicator];
-    }
+	if (![[[NSBundle mainBundle] objectForInfoDictionaryKey:@"TSCThunderRequestShouldHideActivityIndicator"] boolValue]) {
+		[ApplicationLoadingIndicatorManager.sharedManager showActivityIndicator];
+	}
 #endif
 }
 
 - (void)TSC_hideApplicationActivity
 {
 #if TARGET_OS_IOS
-    if (![[[NSBundle mainBundle] objectForInfoDictionaryKey:@"TSCThunderRequestShouldHideActivityIndicator"] boolValue]) {
-        [ApplicationLoadingIndicatorManager.sharedManager hideActivityIndicator];
-    }
+	if (![[[NSBundle mainBundle] objectForInfoDictionaryKey:@"TSCThunderRequestShouldHideActivityIndicator"] boolValue]) {
+		[ApplicationLoadingIndicatorManager.sharedManager hideActivityIndicator];
+	}
 #endif
 }
 

--- a/ThunderRequest/TSCRequestController.m
+++ b/ThunderRequest/TSCRequestController.m
@@ -161,6 +161,11 @@ typedef void (^TSCOAuth2CheckCompletion) (BOOL authenticated, NSError *authError
     request.path = path;
     request.URLParameterDictionary = URLParamDictionary;
     request.requestHeaders = self.sharedRequestHeaders;
+	
+	// In some API's an error will be returned if you set a Content-Type header
+	// but don't pass a body (In the case of a GET request you never pass a body)
+	// so for GET requests we nill this out
+	request.requestHeaders["Content-Type"] = nil;
 
     [self scheduleRequest:request completion:completion];
     return request;

--- a/ThunderRequest/TSCRequestController.m
+++ b/ThunderRequest/TSCRequestController.m
@@ -160,12 +160,13 @@ typedef void (^TSCOAuth2CheckCompletion) (BOOL authenticated, NSError *authError
     request.requestHTTPMethod = TSCRequestHTTPMethodGET;
     request.path = path;
     request.URLParameterDictionary = URLParamDictionary;
-    request.requestHeaders = self.sharedRequestHeaders;
 	
+	NSMutableDictionary *requestHeaders = [self.sharedRequestHeaders mutableCopy];
 	// In some API's an error will be returned if you set a Content-Type header
 	// but don't pass a body (In the case of a GET request you never pass a body)
 	// so for GET requests we nill this out
-	request.requestHeaders["Content-Type"] = nil;
+	[requestHeaders removeObjectForKey:@"Content-Type"];
+    request.requestHeaders = requestHeaders;
 
     [self scheduleRequest:request completion:completion];
     return request;


### PR DESCRIPTION
As discovered with the RSPB API, some API requests can cause internal server errors or other issues when the "Content-Type" header is set on a request with an absent `body`. This aims to alleviate those issues.