### PR TITLE
Renamed serviceIdentifier to authIdentifier to fix Apple Rejection.

### DIFF
--- a/ThunderRequest/TSCOAuth2Manager.h
+++ b/ThunderRequest/TSCOAuth2Manager.h
@@ -17,7 +17,7 @@ typedef void (^TSCOAuthAuthenticateCompletion)(TSCOAuth2Credential * __nullable 
 @optional
 
 /**
- This method will be called if a request is made without a TSCOAuthCredential object having been saved to the keychain under -serviceIdentifier
+ This method will be called if a request is made without a TSCOAuthCredential object having been saved to the keychain under -authIdentifier
  @param completion The completion block which should be called when the user has been authenticated
  */
 - (void)authenticateWithCompletion:(nonnull TSCOAuthAuthenticateCompletion)completion;
@@ -35,6 +35,6 @@ typedef void (^TSCOAuthAuthenticateCompletion)(TSCOAuth2Credential * __nullable 
 /**
  This should return the service identifier for the OAuth flow, which the credentials object will be saved into the keychain under
  */
-- (nonnull NSString *)serviceIdentifier;
+- (nonnull NSString *)authIdentifier;
 
 @end

--- a/ThunderRequest/TSCRequestController.m
+++ b/ThunderRequest/TSCRequestController.m
@@ -416,7 +416,7 @@ typedef void (^TSCOAuth2CheckCompletion) (BOOL authenticated, NSError *authError
     if (self.OAuth2Delegate) {
         
         if (!self.sharedRequestCredential || ![self.sharedRequestCredential isKindOfClass:[TSCOAuth2Credential class]]) {
-            self.sharedRequestCredential = [TSCOAuth2Credential retrieveCredentialWithIdentifier:[self.OAuth2Delegate serviceIdentifier]];
+            self.sharedRequestCredential = [TSCOAuth2Credential retrieveCredentialWithIdentifier:[self.OAuth2Delegate authIdentifier]];
         }
         
         // If we got shared credentials and they are OAuth 2 credentials we can continue
@@ -438,7 +438,7 @@ typedef void (^TSCOAuth2CheckCompletion) (BOOL authenticated, NSError *authError
                     if (!error) {
                         
                         if (saveToKeychain) {
-                            [TSCOAuth2Credential storeCredential:credential withIdentifier:[welf.OAuth2Delegate serviceIdentifier]];
+                            [TSCOAuth2Credential storeCredential:credential withIdentifier:[welf.OAuth2Delegate authIdentifier]];
                         }
                         welf.sharedRequestCredential = credential;
                     }
@@ -755,7 +755,7 @@ typedef void (^TSCOAuth2CheckCompletion) (BOOL authenticated, NSError *authError
         return;
     }
     
-    TSCOAuth2Credential *credential = (TSCOAuth2Credential *)[TSCOAuth2Credential retrieveCredentialWithIdentifier:[OAuth2Delegate serviceIdentifier]];
+    TSCOAuth2Credential *credential = (TSCOAuth2Credential *)[TSCOAuth2Credential retrieveCredentialWithIdentifier:[OAuth2Delegate authIdentifier]];
     if (credential) {
         self.sharedRequestCredential = credential;
     }
@@ -781,7 +781,7 @@ typedef void (^TSCOAuth2CheckCompletion) (BOOL authenticated, NSError *authError
     }
     
     if (save) {
-        [[credential class] storeCredential:credential withIdentifier: self.OAuth2Delegate ? [self.OAuth2Delegate serviceIdentifier] : [NSString stringWithFormat:@"thundertable.com.threesidedcube-%@", self.sharedBaseURL]];
+        [[credential class] storeCredential:credential withIdentifier: self.OAuth2Delegate ? [self.OAuth2Delegate authIdentifier] : [NSString stringWithFormat:@"thundertable.com.threesidedcube-%@", self.sharedBaseURL]];
     }
 }
 


### PR DESCRIPTION
Apple no longer permits us to use `serviceIdentifier` as a term. We have renamed to avoid rejections.