### PR TITLE
Fixes `earliestBeginDate` only being available on iOS 11.0

### DIFF
--- a/ThunderRequest/TSCRequestController.m
+++ b/ThunderRequest/TSCRequestController.m
@@ -607,7 +607,10 @@ typedef void (^TSCOAuth2CheckCompletion) (BOOL authenticated, NSError *authError
 			
 			NSURLRequest *normalisedRequest = [self backgroundableRequestObjectFromTSCRequest:request];
 			NSURLSessionDownloadTask *task = [welf.backgroundSession downloadTaskWithRequest:normalisedRequest];
-            task.earliestBeginDate = beginDate;
+            
+            if (@available(iOS 11.0, *)) {
+                task.earliestBeginDate = beginDate;
+            }
 			
 			[welf addCompletionHandler:completion progressHandler:progress forTaskIdentifier:task.taskIdentifier];
             


### PR DESCRIPTION
`earliestBeginDate` on `NSURLSessionDownloadTask` is only available from iOS 11.0, so this adds an availability check to make sure we avoid crashes.