### PR TITLE
Adds missing @available statement for setting date of upload tasks

### DIFF
--- a/ThunderRequest/TSCRequestController.m
+++ b/ThunderRequest/TSCRequestController.m
@@ -668,7 +668,9 @@ typedef void (^TSCOAuth2CheckCompletion) (BOOL authenticated, NSError *authError
 				task = [welf.backgroundSession uploadTaskWithRequest:[welf backgroundableRequestObjectFromTSCRequest:request] fromFile:[NSURL fileURLWithPath:filePath]];
 			}
             
-            task.earliestBeginDate = beginDate;
+            if (@available(iOS 11.0, watchOS 4.0, *)) {
+                task.earliestBeginDate = beginDate;
+            }
 			
 			[welf addCompletionHandler:completion progressHandler:progress forTaskIdentifier:task.taskIdentifier];
 			


### PR DESCRIPTION
PR #22 broke compilation of the app due to one of the uses of `earliestBeginDate` not being wrapped in an @available statement. This fixes that issue.