### PR TITLE
Fixes `HTTP.Errror` bridging to `NSError`

### DIFF
--- a/ThunderRequest/HTTP+Error.swift
+++ b/ThunderRequest/HTTP+Error.swift
@@ -32,3 +32,10 @@ public extension HTTP {
         }
     }
 }
+
+extension HTTP.Error: CustomNSError {
+    
+    public var errorCode: Int {
+        return code
+    }
+}


### PR DESCRIPTION
Conforms HTTP.Error to `CustomNSError` so when bridging to `NSError` it maintains it's `errorCode`