### PR TITLE
Adds option to stop background download controller reading to disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Thunder Request
 
-[![Build Status](https://travis-ci.org/3sidedcube/ThunderRequest.svg)](https://travis-ci.org/3sidedcube/ThunderRequest) [![Swift 5.1](http://img.shields.io/badge/swift-5.1-brightgreen.svg)](https://swift.org/blog/swift-5-1-released/) [![Apache 2](https://img.shields.io/badge/license-Apache%202-brightgreen.svg)](LICENSE.md)
+[![Build Status](https://travis-ci.org/3sidedcube/ThunderRequest.svg)](https://travis-ci.org/3sidedcube/ThunderRequest) [![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage) [![Swift 5.2](http://img.shields.io/badge/swift-5.2-brightgreen.svg)](https://swift.org/blog/swift-5-2-released/) [![Apache 2](https://img.shields.io/badge/license-Apache%202-brightgreen.svg)](LICENSE.md)
 
 Thunder Request is a Framework used to simplify making http and https web requests.
 

--- a/ThunderRequest/RequestController+Callbacks.swift
+++ b/ThunderRequest/RequestController+Callbacks.swift
@@ -49,7 +49,7 @@ extension RequestController {
         
         var requestResponse: RequestResponse?
         if let urlResponse = response {
-            requestResponse = RequestResponse(response: urlResponse, data: nil)
+            requestResponse = RequestResponse(response: urlResponse, data: nil, fileURL: fileURL)
         }
         
         transferCompletionHandlers[taskIdentifier]?(requestResponse, fileURL, error)

--- a/ThunderRequest/RequestController.swift
+++ b/ThunderRequest/RequestController.swift
@@ -624,7 +624,7 @@ open class RequestController {
                     RequestController.hideApplicationActivityIndicator()
                     var returnResponse: RequestResponse?
                     if let requestResponse = response.response {
-                        returnResponse = RequestResponse(response: requestResponse, data: nil)
+                        returnResponse = RequestResponse(response: requestResponse, data: nil, fileURL: response.downloadURL)
                     }
                     completion?(returnResponse, response.downloadURL, error)
                     

--- a/ThunderRequest/RequestResponse.swift
+++ b/ThunderRequest/RequestResponse.swift
@@ -18,6 +18,10 @@ public class RequestResponse {
         return httpResponse?.allHeaderFields
     }
     
+    /// File url the response's data was saved to. This is only present for file downloads and is useful
+    /// to get around the `40mb` memory limit which the Apple background service imposes on background download daemon
+    public let fileURL: URL?
+    
     /// Raw data returned from the server
     public let data: Data?
     
@@ -31,10 +35,11 @@ public class RequestResponse {
     /// Initialises a new request response from a given `URLResponse` and `Data`
     /// - Parameter response: The response to populate properties with
     /// - Parameter data: The data that was returned with the response
-    public init(response: URLResponse, data: Data?) {
-        
+    /// - Parameter fileURL: The file url that the responses download was saved to (Only present for download tasks!)
+    public init(response: URLResponse, data: Data?, fileURL: URL? = nil) {
         httpResponse = response as? HTTPURLResponse
         self.data = data
+        self.fileURL = fileURL
     }
     
     /// The status of the HTTP request as an enum


### PR DESCRIPTION
Added this so we can (try and) avoid Background download daemon's 40mb memory limit!

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a property to background controller init method to stop it reading downloaded file to `Data` immediately.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Has been tested with the implementation of background downloading storm delta bundles in `ThunderCloud`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
