### PR TITLE
Makes background session identifier publicly available

### DIFF
--- a/ThunderRequest/RequestController.swift
+++ b/ThunderRequest/RequestController.swift
@@ -113,6 +113,12 @@ open class RequestController {
     /// Similar to a default session, except that a seperate process handles all data transfers. Background sessions have some additional limitations.
     private var ephemeralSession: URLSession = URLSession(configuration: URLSessionConfiguration.ephemeral)
     
+    /// Returns the session identifier that was used to create the background session's `URLSessionConfiguration` object
+    /// this is useful for checking session identifiers when working with "Background Transfer Service"
+    public var backgroundSessionIdentifier: String? {
+        return backgroundSession.configuration.identifier
+    }
+    
     ///MARK: - Initialization -
     
     internal let dataStore: DataStore


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a property for reading the `RequestController`'s background session configuration identifier

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It was discovered that when using Apple's "Background Transfer Service" sometimes the original request controller which made the request was kept in memory and still available when the delegate method: `application:handleEventsForBackgroundURLSession:completionHandler` is called. In this case if you setup a `BackgroundRequestController` with the same identifier as the original `RequestController` you break the nsurlsessiond. This new property can be used to check if you already have an existing URLSession which will continue to receive delegate messages which can be used in place of a new `BackgroundRequestController`!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Doesn't really need testing, it's just making a property available!

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
