### PR TITLE
Post `Notification` when a `.notConnectedToInternet` `URLError` is re…

### DIFF
--- a/ThunderRequest/RequestController+Callbacks.swift
+++ b/ThunderRequest/RequestController+Callbacks.swift
@@ -18,6 +18,11 @@ extension RequestController {
     
     public static let ErrorDomain = "com.threesidedcube.ThunderRequest"
     
+    /// `Notification` posted when the `Error` from a URL task
+    /// is `URLError.code == .notConnectedToInternet`
+    public static let DidErrorWithNotConnectedToInternetNotificationName =
+        Notification.Name(rawValue: "TSCDidErrorWithNotConnectedToInternet")
+    
     public static let DidReceiveResponseNotificationName = Notification.Name(rawValue: "TSCRequestDidReceiveResponse")
     
     public static let DidErrorNotificationName = Notification.Name("TSCRequestServerError")
@@ -73,6 +78,10 @@ extension RequestController {
         requestInfo[RequestNotificationKey.response] = response
         
         NotificationCenter.default.post(name: RequestController.DidReceiveResponseNotificationName, object: nil, userInfo: requestInfo)
+        
+        if let urlError = error as? URLError, urlError.code == .notConnectedToInternet {
+            NotificationCenter.default.post(name: RequestController.DidErrorWithNotConnectedToInternetNotificationName, object: nil, userInfo: requestInfo)
+        }
         
         if response?.status.isConsideredError == true {
             NotificationCenter.default.post(name: RequestController.DidErrorNotificationName, object: nil, userInfo: requestInfo)

--- a/ThunderRequest/RequestController+Callbacks.swift
+++ b/ThunderRequest/RequestController+Callbacks.swift
@@ -12,16 +12,16 @@ import os.log
 public struct RequestNotificationKey {
     public static let request = "TSCRequestNotificationRequestKey"
     public static let response = "TSCRequestNotificationResponseKey"
+    public static let error = "TSCRequestNotificationErrorKey"
 }
 
 extension RequestController {
     
     public static let ErrorDomain = "com.threesidedcube.ThunderRequest"
     
-    /// `Notification` posted when the `Error` from a URL task
-    /// is `URLError.code == .notConnectedToInternet`
-    public static let DidErrorWithNotConnectedToInternetNotificationName =
-        Notification.Name(rawValue: "TSCDidErrorWithNotConnectedToInternet")
+    /// Name of `Notification` posted when the `Error` from a URL task is a `URLError`
+    public static let RequestDidURLErrorNotificationName =
+        Notification.Name(rawValue: "TSCRequestDidURLError")
     
     public static let DidReceiveResponseNotificationName = Notification.Name(rawValue: "TSCRequestDidReceiveResponse")
     
@@ -79,8 +79,10 @@ extension RequestController {
         
         NotificationCenter.default.post(name: RequestController.DidReceiveResponseNotificationName, object: nil, userInfo: requestInfo)
         
-        if let urlError = error as? URLError, urlError.code == .notConnectedToInternet {
-            NotificationCenter.default.post(name: RequestController.DidErrorWithNotConnectedToInternetNotificationName, object: nil, userInfo: requestInfo)
+        if let urlError = error as? URLError {
+            var userInfo = requestInfo
+            userInfo[RequestNotificationKey.error] = urlError
+            NotificationCenter.default.post(name: RequestController.RequestDidURLErrorNotificationName, object: nil, userInfo: userInfo)
         }
         
         if response?.status.isConsideredError == true {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Post `Notification` when a `.notConnectedToInternet` `URLError` is returned as the `Error` of a URL task

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Apps can listen and respond to this `Notification` and handle accordingly, often with UI.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
