### PR TITLE
Removes unecessary `_` assignment which stops Xcode 12 from compiling

### DIFF
--- a/ThunderRequest/String+MD5.swift
+++ b/ThunderRequest/String+MD5.swift
@@ -19,7 +19,7 @@ public extension String {
         }
         var digestData = Data(count: Int(CC_MD5_DIGEST_LENGTH))
         
-        _ = digestData.withUnsafeMutableBytes { (digestBody: UnsafeMutableRawBufferPointer) in
+        digestData.withUnsafeMutableBytes { (digestBody: UnsafeMutableRawBufferPointer) in
             
             guard let baseAddress = digestBody.baseAddress, digestBody.count > 0 else {
                 return


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Allows compiling against the Swift 5.3 compiler

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allowing use of Xcode 12 for compiling our apps

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Has been tested in Simon's own "Camrote" app

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
