### PR TITLE
Fix `RequestCredential` issue resulting from insecure encoding/decoding

### DIFF
--- a/ThunderRequest/CredentialStore.swift
+++ b/ThunderRequest/CredentialStore.swift
@@ -184,7 +184,7 @@ public struct CredentialStore {
             return nil
         }
         
-        return RequestCredential.init(keychainData: data)
+        return try? RequestCredential(keychainData: data)
     }
     
     /// Deletes an entry for a certain identifier from the keychain

--- a/ThunderRequest/RequestCredential.swift
+++ b/ThunderRequest/RequestCredential.swift
@@ -52,8 +52,9 @@ public final class RequestCredential: NSObject, NSSecureCoding {
     ///
     /// - Parameter keychainData: The data which was retrieved from the keychain
     init(keychainData: Data) throws {
+        // Root object RequestCredential and other encoded types
         let requestCredential = try NSKeyedUnarchiver.unarchivedObject(
-            ofClasses: [RequestCredential.self, NSString.self],
+            ofClasses: [RequestCredential.self, NSString.self, NSDate.self],
             from: keychainData
         )
 

--- a/ThunderRequest/RequestCredential.swift
+++ b/ThunderRequest/RequestCredential.swift
@@ -21,47 +21,52 @@ public let kTSCAuthServiceName = "TSCAuthCredential"
 
 /// A class used to store authentication information and return the `URLCredential` object when required
 @objc(TSCRequestCredential)
-public final class RequestCredential: NSObject, NSCoding {
-    
+public final class RequestCredential: NSObject, NSSecureCoding {
+
     /// Returns the url credential which can be used to authenticate a request
-    public var credential: URLCredential?
-    
+    public var credential: URLCredential? {
+        guard let username = username else { return nil }
+        guard let password = password else { return nil }
+        return URLCredential(user: username, password: password, persistence: .none)
+    }
+
     /// The username to auth the user with
     public var username: String?
-    
+
     /// The password to auth the user with
     public var password: String?
-    
+
     /// The auth token to auth the user with
     public var authorizationToken: String?
-    
+
     /// The type of the token
     public var tokenType: String = Authentication.TokenType.bearer
-    
+
     /// The date on which the authorization token expires
     public var expirationDate: Date?
-    
+
     /// The refresh token to be sent back to the authenticating endpoint for certain auth methods
     public var refreshToken: String?
-    
+
     /// Init method for re-constructing from data stored in the user's keychain
     ///
     /// - Parameter keychainData: The data which was retrieved from the keychain
-    init?(keychainData: Data) {
-        guard let credential = try? NSKeyedUnarchiver.unarchivedObject(
-            ofClass: RequestCredential.self,
+    init(keychainData: Data) throws {
+        let requestCredential = try NSKeyedUnarchiver.unarchivedObject(
+            ofClasses: [RequestCredential.self, NSString.self],
             from: keychainData
-        ) else {
-            return nil
+        )
+
+        guard let credential = requestCredential as? RequestCredential else {
+            throw RequestCredentialError.invalidType
         }
-        
+
         self.authorizationToken = credential.authorizationToken
-        self.credential = credential.credential
         self.username = credential.username
         self.password = credential.password
         self.tokenType = credential.tokenType
     }
-    
+
     /// Whether the credential has expired. Where expiryDate is missing this will return as false, as it is
     /// assumed the credential doesn't have an expiry date in this case
     public var hasExpired: Bool {
@@ -70,7 +75,7 @@ public final class RequestCredential: NSObject, NSCoding {
         }
         return Date() > expiry
     }
-    
+
     /// The data to store in the keychain
     public func keychainData() throws -> Data {
         return try NSKeyedArchiver.archivedData(
@@ -78,7 +83,7 @@ public final class RequestCredential: NSObject, NSCoding {
             requiringSecureCoding: false
         )
     }
-    
+
     /// Creates a new username/password based credential
     ///
     /// - Parameters:
@@ -86,11 +91,10 @@ public final class RequestCredential: NSObject, NSCoding {
     ///   - password: The password of the authorization object
     public init(username: String, password: String) {
         super.init()
-        credential = URLCredential(user: username, password: password, persistence: .none)
         self.username = username
         self.password = password
     }
-    
+
     /// Initialises a new OAuth2 credential with given parameters
     ///
     /// - Parameters:
@@ -99,14 +103,14 @@ public final class RequestCredential: NSObject, NSCoding {
     ///   - expiryDate: The date upon which the credential will expire for the user.
     ///   - tokenType: The token type of the credential (Defaults to Bearer)
     public init(authorizationToken: String, refreshToken: String?, expiryDate: Date, tokenType: String = "Bearer") {
-        
+
         self.refreshToken = refreshToken
         self.expirationDate = expiryDate
         self.authorizationToken = authorizationToken
         self.tokenType = tokenType
         super.init()
     }
-    
+
     /// Creates a new auth token based credential
     ///
     /// - Parameter authorizationToken: The authorization token to use
@@ -114,35 +118,42 @@ public final class RequestCredential: NSObject, NSCoding {
         super.init()
         self.authorizationToken = authorizationToken
     }
-    
+
     private enum CodingKeys: String {
         case username
         case password
         case authToken = "authtoken"
-        case credential
         case tokenType = "tokentype"
         case expiration
         case refreshToken = "refreshtoken"
     }
-    
+
     public func encode(with aCoder: NSCoder) {
         aCoder.encode(username, forKey: CodingKeys.username.rawValue)
         aCoder.encode(password, forKey: CodingKeys.password.rawValue)
         aCoder.encode(authorizationToken, forKey: CodingKeys.authToken.rawValue)
-        aCoder.encode(credential, forKey: CodingKeys.credential.rawValue)
         aCoder.encode(tokenType, forKey: CodingKeys.tokenType.rawValue)
         aCoder.encode(expirationDate, forKey: CodingKeys.expiration.rawValue)
         aCoder.encode(refreshToken, forKey: CodingKeys.refreshToken.rawValue)
     }
-    
+
     required public init?(coder aDecoder: NSCoder) {
         super.init()
         username = aDecoder.decodeObject(forKey: CodingKeys.username.rawValue) as? String
         password = aDecoder.decodeObject(forKey: CodingKeys.password.rawValue) as? String
         authorizationToken = aDecoder.decodeObject(forKey: CodingKeys.authToken.rawValue) as? String
-        credential = aDecoder.decodeObject(forKey: CodingKeys.credential.rawValue) as? URLCredential
         tokenType = aDecoder.decodeObject(forKey: CodingKeys.tokenType.rawValue) as? String ?? Authentication.TokenType.bearer
         refreshToken = aDecoder.decodeObject(forKey: CodingKeys.refreshToken.rawValue) as? String
         expirationDate = aDecoder.decodeObject(forKey: CodingKeys.expiration.rawValue) as? Date
     }
+
+    // MARK: - NSSecureCoding
+
+    public static var supportsSecureCoding: Bool {
+        return true
+    }
+}
+
+enum RequestCredentialError: Error {
+    case invalidType
 }


### PR DESCRIPTION
## Description
As `RequestCredential` conformed to `NSCoding` instead of `NSSecureCoding` unarchiving would log the following error:
```
Error Domain=NSCocoaErrorDomain Code=4864 \"This decoder will only decode classes that adopt NSSecureCoding. Class \'TSCRequestCredential\' does not adopt it.\" UserInfo={NSDebugDescription=This decoder will only decode classes that adopt NSSecureCoding. Class \'TSCRequestCredential\' does not adopt it.}
```

Moreover, when unarchiving, types should be declared as so:
```
NSKeyedUnarchiver.unarchivedObject(
    ofClasses: [RequestCredential.self, NSString.self],
    from: keychainData
) as? RequestCredential
```

otherwise, the following error will be logged
```
[general] *** -[NSKeyedUnarchiver validateAllowedClass:forKey:] allowed unarchiving safe plist type ''NSString' (0x1da1637d0) [/System/Library/Frameworks/Foundation.framework]' for key 'password', even though it was not explicitly included in the client allowed classes set: '{(
    "'TSCRequestCredential' (0x102a856d8) [...]"
)}'. This will be disallowed in the future.
```

## Related Issue
https://3sidedcube.atlassian.net/browse/SP-771

## Motivation and Context
Bug fix, breaking change from Apple around archiving/unarchiving. 

## How Has This Been Tested?
SAF (Hero Care)

## Screenshots (if appropriate):
Not applicable

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Apps using the public interface here may still be able to use this change without any "breaking changes".
But the `credentials` property of `RequestCredential` is now computed, and the archived/unarchived data will be different.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
